### PR TITLE
mcrockett/Fix bug with no service active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.15.0] - [2020-06-12]
+### Added
+- Extensions - InNetworkMissing for plans that don't provide in network indicators.
+
+### Fixed
+- Bug where active codes with no service codes cause exception.
+
 ## [0.14.0] - [2020-05-07]
 ### Added
 - Extensions - mixins for common overrides
@@ -104,6 +111,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Authentication
 - Configuration
 
+[0.15.0]: https://github.com/WeInfuse/change_health/compare/v0.14.0...v0.15.0
 [0.14.0]: https://github.com/WeInfuse/change_health/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/WeInfuse/change_health/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/WeInfuse/change_health/compare/v0.11.0...v0.12.0

--- a/lib/change_health/extensions.rb
+++ b/lib/change_health/extensions.rb
@@ -6,6 +6,12 @@ module ChangeHealth
       end
     end
 
+    module InNetworkMissing
+      def in_network
+        self.where_not(inPlanNetworkIndicatorCode: 'N')
+      end
+    end
+
     module DeductiblesIgnoreSpecialistZero
       def deductibles
         super.where_not(serviceTypeCodes: '98', benefitAmount: '0')

--- a/lib/change_health/models/eligibility_benefit.rb
+++ b/lib/change_health/models/eligibility_benefit.rb
@@ -18,6 +18,7 @@ module ChangeHealth
       EMPLOYEE_AND_SPOUSE = 'ESP'
 
       VISIT         = '27'
+      SERVICE_YEAR  = '22'
       YEAR          = '23'
       YTD           = '24'
       DAY           =  '7'

--- a/lib/change_health/models/eligibility_data.rb
+++ b/lib/change_health/models/eligibility_data.rb
@@ -65,7 +65,7 @@ module ChangeHealth
       end
 
       def plan_status(service_code: )
-        self.planStatus&.find {|plan| plan.dig('serviceTypeCodes').include?(service_code) } || {}
+        self.planStatus&.find {|plan| plan.dig('serviceTypeCodes')&.include?(service_code) } || {}
       end
 
       def benefits

--- a/lib/change_health/version.rb
+++ b/lib/change_health/version.rb
@@ -1,3 +1,3 @@
 module ChangeHealth
-  VERSION = '0.14.0'.freeze
+  VERSION = '0.15.0'.freeze
 end

--- a/test/change_health/models/eligibility_data_test.rb
+++ b/test/change_health/models/eligibility_data_test.rb
@@ -221,6 +221,40 @@ class EligibilityDataTest < Minitest::Test
           assert(edata.active?)
         end
 
+        describe 'no service codes' do
+          let(:altered_data) {
+            d = load_sample('000050.example.response.json', parse: true);
+            d['planStatus'] = altered_plan_status
+            d
+          }
+          let(:json_data) { altered_data }
+
+          describe 'no other codes' do
+            let(:altered_plan_status) {
+              [
+                {"statusCode" => "1","status" => "Active Coverage","planDetails" => "OTHER"}
+              ]
+            }
+
+            it 'is false' do
+              assert_equal(false, edata.active?)
+            end
+          end
+
+          describe 'other active code' do
+            let(:altered_plan_status) {
+              [
+                {"statusCode" => "1","status" => "Active Coverage","planDetails" => "OTHER"},
+                {"statusCode" => "1","status" => "Active Coverage","planDetails" => "BASIC", "serviceTypeCodes" => [ "30" ]}
+              ]
+            }
+
+            it 'is true' do
+              assert_equal(true, edata.active?)
+            end
+          end
+        end
+
         describe 'false' do
           it 'non zero codes' do
             assert_equal(false, edata_inactive.active?)


### PR DESCRIPTION
** What **
- Can ignore no service codes in plan status filter

** Why **
- Some trading partners have no service codes in the active and it's throwing in the gem