### PR TITLE
181334925 check_or_eft_trace_number to Report835Claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+# [3.4.0] - 2022-03-23
+### Added
+* Report835Claim - check_or_eft_trace_number
+
 # [3.3.0] - 2022-02-11
 ### Added
 * Report277Claim - 'message' from informationClaimStatuses, clearinghouse_trace_number, patient_account_number, referenced_transaction_trace_number, trading_partner_claim_number
@@ -236,6 +240,7 @@ Added the ability to hit professional claim submission API. For more details, se
 - Authentication
 - Configuration
 
+[3.4.0]: https://github.com/WeInfuse/change_health/compare/v3.3.0...v3.4.0
 [3.3.0]: https://github.com/WeInfuse/change_health/compare/v3.2.0...v3.3.0
 [3.2.0]: https://github.com/WeInfuse/change_health/compare/v3.1.0...v3.2.0
 [3.1.0]: https://github.com/WeInfuse/change_health/compare/v3.0.0...v3.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 # [3.4.0] - 2022-03-23
 ### Added
-* Report835Claim - check_or_eft_trace_number
+* Report835Claim - check_or_eft_trace_number & check_issue_or_eft_effective_date
 
 # [3.3.0] - 2022-02-11
 ### Added

--- a/lib/change_health/response/claim/report/report_835_claim.rb
+++ b/lib/change_health/response/claim/report/report_835_claim.rb
@@ -2,6 +2,7 @@ module ChangeHealth
   module Response
     module Claim
       class Report835Claim < ReportClaim
+        property :check_or_eft_trace_number, required: false
         property :claim_payment_remark_codes, required: false
         property :patient_control_number, required: false
         property :payer_claim_control_number, required: false

--- a/lib/change_health/response/claim/report/report_835_claim.rb
+++ b/lib/change_health/response/claim/report/report_835_claim.rb
@@ -2,6 +2,7 @@ module ChangeHealth
   module Response
     module Claim
       class Report835Claim < ReportClaim
+        property :check_issue_or_eft_effective_date, required: false
         property :check_or_eft_trace_number, required: false
         property :claim_payment_remark_codes, required: false
         property :patient_control_number, required: false

--- a/lib/change_health/response/claim/report/report_835_data.rb
+++ b/lib/change_health/response/claim/report/report_835_data.rb
@@ -11,6 +11,10 @@ module ChangeHealth
           transactions&.first&.dig('paymentAndRemitReassociationDetails', 'checkOrEFTTraceNumber')
         end
 
+        def check_issue_or_eft_effective_date
+          ChangeHealth::Models::PARSE_DATE.call(transactions&.first&.dig('financialInformation', 'checkIssueOrEFTEffectiveDate'))
+        end
+
         def payer_identification
           transactions&.first&.dig('payer', 'payerIdentificationNumber')
         end
@@ -107,6 +111,7 @@ module ChangeHealth
                 end
 
                 report_claims << Report835Claim.new(
+                  check_issue_or_eft_effective_date: check_issue_or_eft_effective_date,
                   check_or_eft_trace_number: check_or_eft_trace_number,
                   claim_payment_remark_codes: claim_payment_remark_codes,
                   patient_control_number: patient_control_number,

--- a/lib/change_health/response/claim/report/report_835_data.rb
+++ b/lib/change_health/response/claim/report/report_835_data.rb
@@ -7,6 +7,14 @@ module ChangeHealth
           @raw['transactions']
         end
 
+        def check_or_eft_trace_number
+          transactions&.first&.dig('paymentAndRemitReassociationDetails', 'checkOrEFTTraceNumber')
+        end
+
+        def payer_identification
+          transactions&.first&.dig('payer', 'payerIdentificationNumber')
+        end
+
         # Only one payer per report
         def payer_name
           transactions&.first&.dig('payer')&.dig('name')
@@ -28,13 +36,6 @@ module ChangeHealth
           report_claims = []
 
           transactions&.each do |transaction|
-            payment_method_code = transaction.dig('financialInformation', 'paymentMethodCode')
-            payer_name = transaction.dig('payer', 'name')
-            payer_identification = transaction.dig('payer', 'payerIdentificationNumber')
-            report_creation_date = ChangeHealth::Models::PARSE_DATE.call(transaction['productionDate'])
-            total_actual_provider_payment_amount = transaction.dig('financialInformation',
-                                                                   'totalActualProviderPaymentAmount')
-
             transaction['detailInfo']&.each do |detail_info|
               detail_info['paymentInfo']&.each do |payment_info|
                 patient_control_number = payment_info.dig('claimPaymentInfo', 'patientControlNumber')
@@ -56,8 +57,7 @@ module ChangeHealth
 
                 service_date_begin = nil
                 service_date_end = nil
-                service_lines = []
-                payment_info['serviceLines']&.each do |service_line|
+                service_lines = payment_info['serviceLines']&.map do |service_line|
                   service_line_date = ChangeHealth::Models::PARSE_DATE.call(service_line['serviceDate'])
                   if service_date_begin.nil? || service_line_date < service_date_begin
                     service_date_begin = service_line_date
@@ -70,8 +70,7 @@ module ChangeHealth
                   line_item_provider_payment_amount = service_line.dig('servicePaymentInformation',
                                                                        'lineItemProviderPaymentAmount')
 
-                  service_adjustments = []
-                  service_line['serviceAdjustments']&.each do |service_adjustment|
+                  service_adjustments = service_line['serviceAdjustments']&.map do |service_adjustment|
                     adjustments = {}
                     service_adjustment_index = 1
                     while service_adjustment["adjustmentReasonCode#{service_adjustment_index}"]
@@ -83,22 +82,21 @@ module ChangeHealth
 
                     claim_adjustment_group_code = service_adjustment['claimAdjustmentGroupCode']
 
-                    service_adjustments << Report835ServiceAdjustment.new(
+                    Report835ServiceAdjustment.new(
                       adjustments: adjustments,
                       claim_adjustment_group_code: claim_adjustment_group_code
                     )
                   end
 
-                  health_care_check_remark_codes = []
-                  service_line['healthCareCheckRemarkCodes']&.each do |health_care_check_remark_code|
-                    health_care_check_remark_codes << Report835HealthCareCheckRemarkCode.new(
+                  health_care_check_remark_codes = service_line['healthCareCheckRemarkCodes']&.map do |health_care_check_remark_code|
+                    Report835HealthCareCheckRemarkCode.new(
                       code_list_qualifier_code: health_care_check_remark_code['codeListQualifierCode'],
                       code_list_qualifier_code_value: health_care_check_remark_code['codeListQualifierCodeValue'],
                       remark_code: health_care_check_remark_code['remarkCode']
                     )
                   end
 
-                  service_lines << Report835ServiceLine.new(
+                  Report835ServiceLine.new(
                     adjudicated_procedure_code: adjudicated_procedure_code,
                     allowed_actual: allowed_actual,
                     line_item_charge_amount: line_item_charge_amount,
@@ -109,6 +107,7 @@ module ChangeHealth
                 end
 
                 report_claims << Report835Claim.new(
+                  check_or_eft_trace_number: check_or_eft_trace_number,
                   claim_payment_remark_codes: claim_payment_remark_codes,
                   patient_control_number: patient_control_number,
                   patient_first_name: patient_first_name,

--- a/lib/change_health/version.rb
+++ b/lib/change_health/version.rb
@@ -1,3 +1,3 @@
 module ChangeHealth
-  VERSION = '3.3.0'.freeze
+  VERSION = '3.4.0'.freeze
 end

--- a/test/change_health/response/claim/report/report_835_data_test.rb
+++ b/test/change_health/response/claim/report/report_835_data_test.rb
@@ -10,6 +10,10 @@ class Report835DataTest < Minitest::Test
       assert_equal 1, report_data.transactions.size
     end
 
+    it 'check_issue_or_eft_effective_date' do
+      assert_equal Date.new(2019, 3, 31), report_data.check_issue_or_eft_effective_date
+    end
+
     it 'check_or_eft_trace_number' do
       assert_equal '12345', report_data.check_or_eft_trace_number
     end
@@ -69,6 +73,7 @@ class Report835DataTest < Minitest::Test
         service_lines += [1, 2, 3, 4]
 
         expected_claim = ChangeHealth::Response::Claim::Report835Claim.new(
+          check_issue_or_eft_effective_date: Date.new(2019, 3, 31),
           check_or_eft_trace_number: '12345',
           claim_payment_remark_codes: ['N520'],
           patient_control_number: '7722337',

--- a/test/change_health/response/claim/report/report_835_data_test.rb
+++ b/test/change_health/response/claim/report/report_835_data_test.rb
@@ -10,6 +10,14 @@ class Report835DataTest < Minitest::Test
       assert_equal 1, report_data.transactions.size
     end
 
+    it 'check_or_eft_trace_number' do
+      assert_equal '12345', report_data.check_or_eft_trace_number
+    end
+
+    it 'payer_identification' do
+      assert_equal '06102', report_data.payer_identification
+    end
+
     it 'payer_name' do
       assert_equal 'DENTAL OF ABC', report_data.payer_name
     end
@@ -61,6 +69,7 @@ class Report835DataTest < Minitest::Test
         service_lines += [1, 2, 3, 4]
 
         expected_claim = ChangeHealth::Response::Claim::Report835Claim.new(
+          check_or_eft_trace_number: '12345',
           claim_payment_remark_codes: ['N520'],
           patient_control_number: '7722337',
           patient_first_name: 'SANDY',


### PR DESCRIPTION
Need to be able to access check_or_eft_trace_number field from 835s
Use `Report835Data` methods instead of digging twice
Use `= .map` instead of `= []; .each <<`
