### PR TITLE
D seow/Claim Note Addition to Serializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+# [3.5.2] - 2022-04-27
+
+* Added properties of `claimNote` to `claimInformation` so it will serialize properly into JSON
+
 # [3.5.1] - 2022-04-12
 
 * Added properties of `lineAdjudicationInformation` and `otherSubscriberInformation` so they can serialize correctly into JSON
@@ -345,7 +349,8 @@ Added the ability to hit professional claim submission API. For more details, se
 * Authentication
 * Configuration
 
-[3.5.1]: https://github.com/WeInfuse/change_health/compare/v3.4.0...v3.5.1
+[3.5.2]: https://github.com/WeInfuse/change_health/compare/v3.5.1...v3.5.2
+[3.5.1]: https://github.com/WeInfuse/change_health/compare/v3.5.0...v3.5.1
 [3.5.0]: https://github.com/WeInfuse/change_health/compare/v3.4.0...v3.5.0
 [3.4.0]: https://github.com/WeInfuse/change_health/compare/v3.3.0...v3.4.0
 [3.3.0]: https://github.com/WeInfuse/change_health/compare/v3.2.0...v3.3.0

--- a/lib/change_health/models/claim/submission/claim_information.rb
+++ b/lib/change_health/models/claim/submission/claim_information.rb
@@ -16,6 +16,7 @@ module ChangeHealth
         property :serviceLines, from: :service_lines, required: false
         property :signatureIndicator, from: :signature_indicator, required: false
         property :otherSubscriberInformation, from: :other_subscriber_information, required: false
+        property :claimNote, from: :claim_note, required: false
 
         def add_service_line(service_line)
           self[:serviceLines] ||= []

--- a/lib/change_health/version.rb
+++ b/lib/change_health/version.rb
@@ -1,3 +1,3 @@
 module ChangeHealth
-  VERSION = '3.5.1'.freeze
+  VERSION = '3.5.2'.freeze
 end


### PR DESCRIPTION
This adds the `claimNote` field to our change_health serializer so it can go through the API. Connect to this PR: https://github.com/WeInfuse/weinfuse_api/pull/2290