### PR TITLE
182817123 DSeow/Fix Secondary Submissions Bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+# [4.2.2] - 2022-07-27
+
+* Fixed ChangeHealth::Response::Claim::Report835ServiceLine's `create_adjustment_detail_array` so that if it is `nil` for `health_care_check_remark_codes`, it does not error out
+
 # [4.2.1] - 2022-07-08
 
 ### Added
@@ -389,6 +393,7 @@ Added the ability to hit professional claim submission API. For more details, se
 * Authentication
 * Configuration
 
+[4.2.2]: https://github.com/WeInfuse/change_health/compare/v4.2.0...v4.2.2
 [4.2.1]: https://github.com/WeInfuse/change_health/compare/v4.2.0...v4.2.1
 [4.2.0]: https://github.com/WeInfuse/change_health/compare/v4.1.0...v4.2.0
 [4.1.0]: https://github.com/WeInfuse/change_health/compare/v4.0.0...v4.1.0

--- a/lib/change_health/response/claim/report/report_835_service_line.rb
+++ b/lib/change_health/response/claim/report/report_835_service_line.rb
@@ -42,7 +42,7 @@ module ChangeHealth
           end
 
           health_care_check_remark_codes = self[:health_care_check_remark_codes]
-          health_care_check_remark_codes.each do |remark_codes|
+          health_care_check_remark_codes&.each do |remark_codes|
             adjustment_details << create_remark_code_adjustments(remark_codes)
           end
           adjustment_details

--- a/lib/change_health/version.rb
+++ b/lib/change_health/version.rb
@@ -1,3 +1,3 @@
 module ChangeHealth
-  VERSION = '4.2.1'.freeze
+  VERSION = '4.2.2'.freeze
 end

--- a/test/change_health/response/claim/report/report_835_service_line_test.rb
+++ b/test/change_health/response/claim/report/report_835_service_line_test.rb
@@ -37,6 +37,11 @@ class Report835ServiceLineTest < Minitest::Test
          health_care_check_remark_codes: [health_care_check_remark_code, health_care_check_remark_code_2])
       end
 
+      let(:claim_information_with_nil_codes) do
+         ChangeHealth::Response::Claim::Report835ServiceLine.new(adjudicated_procedure_code: 'J1745', allowed_actual: 30_720.0, line_item_charge_amount: 48_000.0, line_item_provider_payment_amount: '18432', service_adjustments: [service_adjustments, service_adjustments_2],
+         health_care_check_remark_codes: nil)
+      end
+
       it 'creates adjustments correctly when there are multiple adjustments in a group code' do
          expected_answer = [
             {
@@ -118,6 +123,39 @@ class Report835ServiceLineTest < Minitest::Test
          ]
 
          actual_result = claim_information_with_remark_codes.create_adjustment_detail_array
+         assert_equal(expected_result, actual_result)
+      end
+
+      it 'creates adjustments correctly when there are remark codes' do
+         expected_result = [
+            {
+               adjustmentDetails: [
+               {
+                  adjustmentReasonCode: "45",
+                  adjustmentAmount: "180.82"
+               },
+               {
+                  adjustmentReasonCode: "253",
+                  adjustmentAmount: "13.24"
+               },
+               {
+                  adjustmentReasonCode: "59", adjustmentAmount: "827.59"
+               }
+               ],
+               adjustmentGroupCode: "PR"
+            },
+            {
+               adjustmentDetails: [
+               {
+                  adjustmentReasonCode: "2",
+                  adjustmentAmount: "165.52"
+               }
+               ],
+               adjustmentGroupCode: "CO"
+            }
+         ]
+
+         actual_result = claim_information_with_nil_codes.create_adjustment_detail_array
          assert_equal(expected_result, actual_result)
       end
    end


### PR DESCRIPTION
(Ticket)[https://www.pivotaltracker.com/n/projects/2498840/stories/182817123]

There's an error where we iterate on an attribute that could be `nil`, which throws an error in prod and stops our ability to make claims submissions. (Usually happens on secondary claims). This fixes that.