### PR TITLE
DSeow/Fix-Attempt-For-Secondary-Submissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+# [4.2.3] - 2022-07-28
+
+* Adjusted `adjustmentAmount` in object returned from create_adjustment_detail_array to a `0` value instead of an empty string
+
 # [4.2.2] - 2022-07-27
 
 * Fixed ChangeHealth::Response::Claim::Report835ServiceLine's `create_adjustment_detail_array` so that if it is `nil` for `health_care_check_remark_codes`, it does not error out
@@ -393,7 +397,8 @@ Added the ability to hit professional claim submission API. For more details, se
 * Authentication
 * Configuration
 
-[4.2.2]: https://github.com/WeInfuse/change_health/compare/v4.2.0...v4.2.2
+[4.2.2]: https://github.com/WeInfuse/change_health/compare/v4.2.2...v4.2.3
+[4.2.2]: https://github.com/WeInfuse/change_health/compare/v4.2.1...v4.2.2
 [4.2.1]: https://github.com/WeInfuse/change_health/compare/v4.2.0...v4.2.1
 [4.2.0]: https://github.com/WeInfuse/change_health/compare/v4.1.0...v4.2.0
 [4.1.0]: https://github.com/WeInfuse/change_health/compare/v4.0.0...v4.1.0

--- a/lib/change_health/response/claim/report/report_835_service_line.rb
+++ b/lib/change_health/response/claim/report/report_835_service_line.rb
@@ -26,7 +26,7 @@ module ChangeHealth
           adjustment_array = remark_codes_array.map do |_key, value|
             {
               adjustmentReasonCode: value,
-              adjustmentAmount: ""
+              adjustmentAmount: "0"
             }
           end
           {

--- a/lib/change_health/version.rb
+++ b/lib/change_health/version.rb
@@ -1,3 +1,3 @@
 module ChangeHealth
-  VERSION = '4.2.2'.freeze
+  VERSION = '4.2.3'.freeze
 end

--- a/test/change_health/response/claim/report/report_835_service_line_test.rb
+++ b/test/change_health/response/claim/report/report_835_service_line_test.rb
@@ -106,7 +106,7 @@ class Report835ServiceLineTest < Minitest::Test
                adjustmentDetails: [
                {
                   adjustmentReasonCode: "M1",
-                  adjustmentAmount: ""
+                  adjustmentAmount: "0"
                }
                ],
                adjustmentGroupCode: ""
@@ -115,7 +115,7 @@ class Report835ServiceLineTest < Minitest::Test
                adjustmentDetails: [
                {
                   adjustmentReasonCode: "N510",
-                  adjustmentAmount: ""
+                  adjustmentAmount: "0"
                }
                ],
                adjustmentGroupCode: ""


### PR DESCRIPTION
We've been told (we think) to change the `adjustmentAmount` to a '0' instead of an empty string so we can submit valid secondary claims. This makes that change.

[Ticket](https://www.pivotaltracker.com/n/projects/2498840/stories/182821252)