### PR TITLE
182817123 DSeow/Fix Secondary Submissions Bug Pt2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+# [4.2.4] - 2022-07-28
+
+* Fixed bug where if a `Report835HealthCareCheckRemarkCode` has either the `code_list_qualifier_code` or `code_list_qualifier_code_value` attribute filled in, `Report835ServiceLine` data is mapped incorrectly in the JSON
+
 # [4.2.3] - 2022-07-28
 
 * Adjusted `adjustmentAmount` in object returned from create_adjustment_detail_array to a `0` value instead of an empty string
@@ -397,7 +401,8 @@ Added the ability to hit professional claim submission API. For more details, se
 * Authentication
 * Configuration
 
-[4.2.2]: https://github.com/WeInfuse/change_health/compare/v4.2.2...v4.2.3
+[4.2.4]: https://github.com/WeInfuse/change_health/compare/v4.2.3...v4.2.4
+[4.2.3]: https://github.com/WeInfuse/change_health/compare/v4.2.2...v4.2.3
 [4.2.2]: https://github.com/WeInfuse/change_health/compare/v4.2.1...v4.2.2
 [4.2.1]: https://github.com/WeInfuse/change_health/compare/v4.2.0...v4.2.1
 [4.2.0]: https://github.com/WeInfuse/change_health/compare/v4.1.0...v4.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 # [4.2.4] - 2022-07-28
 
-* Fixed bug where if a `Report835HealthCareCheckRemarkCode` has either the `code_list_qualifier_code` or `code_list_qualifier_code_value` attribute filled in, `Report835ServiceLine` data is mapped incorrectly in the JSON
+* Removed all RARC Codes (HealthCareCheckRemarkCodes) from JSON
 
 # [4.2.3] - 2022-07-28
 

--- a/lib/change_health/response/claim/report/report_835_service_line.rb
+++ b/lib/change_health/response/claim/report/report_835_service_line.rb
@@ -23,14 +23,14 @@ module ChangeHealth
         end
 
         def create_remark_code_adjustments(remark_codes_array)
-          adjustment_array = remark_codes_array.map do |_key, value|
+          adjustment_array = remark_codes_array.map do |key, value|
             {
               adjustmentReasonCode: value,
               adjustmentAmount: "0"
-            }
+            } if key == :remark_code
           end
           {
-            adjustmentDetails: adjustment_array,
+            adjustmentDetails: adjustment_array.compact,
             adjustmentGroupCode: ""
           }
         end

--- a/lib/change_health/response/claim/report/report_835_service_line.rb
+++ b/lib/change_health/response/claim/report/report_835_service_line.rb
@@ -22,28 +22,10 @@ module ChangeHealth
           }
         end
 
-        def create_remark_code_adjustments(remark_codes_array)
-          adjustment_array = remark_codes_array.map do |key, value|
-            {
-              adjustmentReasonCode: value,
-              adjustmentAmount: "0"
-            } if key == :remark_code
-          end
-          {
-            adjustmentDetails: adjustment_array.compact,
-            adjustmentGroupCode: ""
-          }
-        end
-
         def create_adjustment_detail_array
           all_service_adjustments = self.service_adjustments
           adjustment_details = all_service_adjustments.map do |service_adjustments|
             create_group_adjustments(service_adjustments)
-          end
-
-          health_care_check_remark_codes = self[:health_care_check_remark_codes]
-          health_care_check_remark_codes&.each do |remark_codes|
-            adjustment_details << create_remark_code_adjustments(remark_codes)
           end
           adjustment_details
         end

--- a/lib/change_health/version.rb
+++ b/lib/change_health/version.rb
@@ -1,3 +1,3 @@
 module ChangeHealth
-  VERSION = '4.2.3'.freeze
+  VERSION = '4.2.4'.freeze
 end

--- a/test/change_health/response/claim/report/report_835_service_line_test.rb
+++ b/test/change_health/response/claim/report/report_835_service_line_test.rb
@@ -15,33 +15,9 @@ class Report835ServiceLineTest < Minitest::Test
          )
       end
 
-      let(:health_care_check_remark_code) do
-         ChangeHealth::Response::Claim::Report835HealthCareCheckRemarkCode.new(
-         remark_code: "M1",
-         code_list_qualifier_code_value: "Claim Payment Remark Codes",
-         code_list_qualifier_code: "HI"
-         )
-      end
-
-      let(:health_care_check_remark_code_2) do
-         ChangeHealth::Response::Claim::Report835HealthCareCheckRemarkCode.new(
-         remark_code: "N510"
-         )
-      end
-
       let(:claim_information) do
          ChangeHealth::Response::Claim::Report835ServiceLine.new(adjudicated_procedure_code: 'J1745', allowed_actual: 30_720.0, line_item_charge_amount: 48_000.0, line_item_provider_payment_amount: '18432', service_adjustments: [service_adjustments, service_adjustments_2],
          health_care_check_remark_codes: [])
-      end
-
-      let(:claim_information_with_remark_codes) do
-         ChangeHealth::Response::Claim::Report835ServiceLine.new(adjudicated_procedure_code: 'J1745', allowed_actual: 30_720.0, line_item_charge_amount: 48_000.0, line_item_provider_payment_amount: '18432', service_adjustments: [service_adjustments, service_adjustments_2],
-         health_care_check_remark_codes: [health_care_check_remark_code, health_care_check_remark_code_2])
-      end
-
-      let(:claim_information_with_nil_codes) do
-         ChangeHealth::Response::Claim::Report835ServiceLine.new(adjudicated_procedure_code: 'J1745', allowed_actual: 30_720.0, line_item_charge_amount: 48_000.0, line_item_provider_payment_amount: '18432', service_adjustments: [service_adjustments, service_adjustments_2],
-         health_care_check_remark_codes: nil)
       end
 
       it 'creates adjustments correctly when there are multiple adjustments in a group code' do
@@ -75,90 +51,6 @@ class Report835ServiceLineTest < Minitest::Test
 
          actual_result = claim_information.create_adjustment_detail_array
          assert_equal(expected_answer, actual_result)
-      end
-
-      it 'creates adjustments correctly when there are remark codes' do
-         expected_result = [
-            {
-               adjustmentDetails: [
-               {
-                  adjustmentReasonCode: "45",
-                  adjustmentAmount: "180.82"
-               },
-               {
-                  adjustmentReasonCode: "253",
-                  adjustmentAmount: "13.24"
-               },
-               {
-                  adjustmentReasonCode: "59", adjustmentAmount: "827.59"
-               }
-               ],
-               adjustmentGroupCode: "PR"
-            },
-            {
-               adjustmentDetails: [
-               {
-                  adjustmentReasonCode: "2",
-                  adjustmentAmount: "165.52"
-               }
-               ],
-               adjustmentGroupCode: "CO"
-            },
-            {
-               adjustmentDetails: [
-               {
-                  adjustmentReasonCode: "M1",
-                  adjustmentAmount: "0"
-               }
-               ],
-               adjustmentGroupCode: ""
-            },
-            {
-               adjustmentDetails: [
-               {
-                  adjustmentReasonCode: "N510",
-                  adjustmentAmount: "0"
-               }
-               ],
-               adjustmentGroupCode: ""
-            }
-         ]
-
-         actual_result = claim_information_with_remark_codes.create_adjustment_detail_array
-         assert_equal(expected_result, actual_result)
-      end
-
-      it 'creates adjustments correctly when there are remark codes' do
-         expected_result = [
-            {
-               adjustmentDetails: [
-               {
-                  adjustmentReasonCode: "45",
-                  adjustmentAmount: "180.82"
-               },
-               {
-                  adjustmentReasonCode: "253",
-                  adjustmentAmount: "13.24"
-               },
-               {
-                  adjustmentReasonCode: "59", adjustmentAmount: "827.59"
-               }
-               ],
-               adjustmentGroupCode: "PR"
-            },
-            {
-               adjustmentDetails: [
-               {
-                  adjustmentReasonCode: "2",
-                  adjustmentAmount: "165.52"
-               }
-               ],
-               adjustmentGroupCode: "CO"
-            }
-         ]
-
-         actual_result = claim_information_with_nil_codes.create_adjustment_detail_array
-         assert_equal(expected_result, actual_result)
       end
    end
 end

--- a/test/change_health/response/claim/report/report_835_service_line_test.rb
+++ b/test/change_health/response/claim/report/report_835_service_line_test.rb
@@ -17,7 +17,9 @@ class Report835ServiceLineTest < Minitest::Test
 
       let(:health_care_check_remark_code) do
          ChangeHealth::Response::Claim::Report835HealthCareCheckRemarkCode.new(
-         remark_code: "M1"
+         remark_code: "M1",
+         code_list_qualifier_code_value: "Claim Payment Remark Codes",
+         code_list_qualifier_code: "HI"
          )
       end
 


### PR DESCRIPTION
~~There is a bug where if a `Report835HealthCareCheckRemarkCode` has either the `code_list_qualifier_code` or `code_list_qualifier_code_value` attribute filled in, `Report835ServiceLine` data is mapped incorrectly in the JSON. This fixes that so it only maps on `remark_code`.~~

Removed all RARC (Report835HealthCareCheckRemarkCode) codes