### PR TITLE
Handle report 835 service line without service date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+# [4.2.5] - 2022-07-29
+
+### Fixed
+* Report835Data can now handle when a service line doesn't have a service date
+
 # [4.2.4] - 2022-07-28
 
 * Removed all RARC Codes (HealthCareCheckRemarkCodes) from JSON
@@ -401,6 +406,7 @@ Added the ability to hit professional claim submission API. For more details, se
 * Authentication
 * Configuration
 
+[4.2.5]: https://github.com/WeInfuse/change_health/compare/v4.2.4...v4.2.5
 [4.2.4]: https://github.com/WeInfuse/change_health/compare/v4.2.3...v4.2.4
 [4.2.3]: https://github.com/WeInfuse/change_health/compare/v4.2.2...v4.2.3
 [4.2.2]: https://github.com/WeInfuse/change_health/compare/v4.2.1...v4.2.2

--- a/lib/change_health/response/claim/report/report_835_data.rb
+++ b/lib/change_health/response/claim/report/report_835_data.rb
@@ -66,10 +66,14 @@ module ChangeHealth
                 service_date_end = nil
                 service_lines = payment_info['serviceLines']&.map do |service_line|
                   service_line_date = ChangeHealth::Models::PARSE_DATE.call(service_line['serviceDate'])
-                  if service_date_begin.nil? || service_line_date < service_date_begin
-                    service_date_begin = service_line_date
+                  unless service_line_date.nil?
+                    if service_date_begin.nil? || service_line_date < service_date_begin
+                      service_date_begin = service_line_date
+                    end
+                    if service_date_end.nil? || service_date_end < service_line_date
+                      service_date_end = service_line_date
+                    end
                   end
-                  service_date_end = service_line_date if service_date_end.nil? || service_date_end < service_line_date
 
                   adjudicated_procedure_code = service_line.dig('servicePaymentInformation', 'adjudicatedProcedureCode')
                   allowed_actual = service_line.dig('serviceSupplementalAmounts', 'allowedActual')

--- a/lib/change_health/version.rb
+++ b/lib/change_health/version.rb
@@ -1,3 +1,3 @@
 module ChangeHealth
-  VERSION = '4.2.4'.freeze
+  VERSION = '4.2.5'.freeze
 end

--- a/test/samples/claim/report/report.R5000000.WC.json.response.json
+++ b/test/samples/claim/report/report.R5000000.WC.json.response.json
@@ -737,7 +737,6 @@
                                     }
                                 },
                                 {
-                                    "serviceDate": "20190321",
                                     "servicePaymentInformation": {
                                         "productOrServiceIDQualifier": "AD",
                                         "productOrServiceIDQualifierValue": "American Dental Association Codes",


### PR DESCRIPTION
Pesky `undefined method < for nil` errors will hopefully be no more