### PR TITLE
182832981 alternative way to get service dates in 835

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+# [4.3.0] - 2022-08-08
+
+### Added
+
+* Report835Data - add another way to get service_date_begin & service_date_end
+
 # [4.2.5] - 2022-07-29
 
 ### Fixed
@@ -406,6 +412,7 @@ Added the ability to hit professional claim submission API. For more details, se
 * Authentication
 * Configuration
 
+[4.3.0]: https://github.com/WeInfuse/change_health/compare/v4.2.5...v4.3.0
 [4.2.5]: https://github.com/WeInfuse/change_health/compare/v4.2.4...v4.2.5
 [4.2.4]: https://github.com/WeInfuse/change_health/compare/v4.2.3...v4.2.4
 [4.2.3]: https://github.com/WeInfuse/change_health/compare/v4.2.2...v4.2.3

--- a/lib/change_health/response/claim/report/report_835_data.rb
+++ b/lib/change_health/response/claim/report/report_835_data.rb
@@ -117,6 +117,11 @@ module ChangeHealth
                   )
                 end
 
+                if service_date_begin.nil? && service_date_end.nil?
+                  service_date_begin = ChangeHealth::Models::PARSE_DATE.call(payment_info['claimStatementPeriodStart'])
+                  service_date_end = ChangeHealth::Models::PARSE_DATE.call(payment_info['claimStatementPeriodEnd'])
+                end
+
                 Report835Claim.new(
                   claim_payment_remark_codes: claim_payment_remark_codes,
                   patient_control_number: patient_control_number,

--- a/lib/change_health/version.rb
+++ b/lib/change_health/version.rb
@@ -1,3 +1,3 @@
 module ChangeHealth
-  VERSION = '4.2.5'.freeze
+  VERSION = '4.3.0'.freeze
 end

--- a/test/change_health/response/claim/report/report_835_data_test.rb
+++ b/test/change_health/response/claim/report/report_835_data_test.rb
@@ -133,6 +133,7 @@ class Report835DataTest < Minitest::Test
       describe 'claim field oddities' do
         let(:odd_claim1) { report_data.payments[1].claims[0] }
         let(:odd_claim2) { report_data.payments[2].claims[0] }
+        let(:odd_claim_service_date) { report_data.payments[2].claims[2] }
         it 'member id' do
           assert_equal 'SJD11122', odd_claim1.patient_member_id
         end
@@ -143,6 +144,11 @@ class Report835DataTest < Minitest::Test
 
         it 'provider npi from payee npi' do
           assert_equal '9999947036', odd_claim2.service_provider_npi
+        end
+
+        it 'service line serviceDate missing' do
+          assert_equal Date.new(2019, 3, 23), odd_claim_service_date.service_date_begin
+          assert_equal Date.new(2019, 3, 24), odd_claim_service_date.service_date_end
         end
       end
     end

--- a/test/samples/claim/report/report.R5000000.WC.json.response.json
+++ b/test/samples/claim/report/report.R5000000.WC.json.response.json
@@ -1030,6 +1030,8 @@
                             ]
                         },
                         {
+                            "claimStatementPeriodStart": "20190323",
+                            "claimStatementPeriodEnd": "20190324",
                             "claimPaymentInfo": {
                                 "patientControlNumber": "7722337",
                                 "claimStatusCode": "1",
@@ -1055,7 +1057,6 @@
                             },
                             "serviceLines": [
                                 {
-                                    "serviceDate": "20190324",
                                     "servicePaymentInformation": {
                                         "productOrServiceIDQualifier": "AD",
                                         "productOrServiceIDQualifierValue": "American Dental Association Codes",
@@ -1076,7 +1077,6 @@
                                     }
                                 },
                                 {
-                                    "serviceDate": "20190324",
                                     "servicePaymentInformation": {
                                         "productOrServiceIDQualifier": "AD",
                                         "productOrServiceIDQualifierValue": "American Dental Association Codes",
@@ -1097,7 +1097,6 @@
                                     }
                                 },
                                 {
-                                    "serviceDate": "20190324",
                                     "servicePaymentInformation": {
                                         "productOrServiceIDQualifier": "AD",
                                         "productOrServiceIDQualifierValue": "American Dental Association Codes",
@@ -1118,7 +1117,6 @@
                                     }
                                 },
                                 {
-                                    "serviceDate": "20190324",
                                     "servicePaymentInformation": {
                                         "productOrServiceIDQualifier": "AD",
                                         "productOrServiceIDQualifierValue": "American Dental Association Codes",


### PR DESCRIPTION
Sometimes each serviceLine does not have a serviceDate. If serviceDate is not there, claimStatementPeriodStart and claimStatementPeriodEnd is supposed to be there so we can use that instead