### PR TITLE
183866185 Can pull any report type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+# [4.10.0] - 2022-12-01
+
+### Added
+
+* Request Report - can now pull back any kind of report, not just 277 or 835
+
 # [4.9.0] - 2022-11-11
 
 ### Added
@@ -448,7 +454,8 @@ Added the ability to hit professional claim submission API. For more details, se
 * Authentication
 * Configuration
 
-[4.8.0]: https://github.com/WeInfuse/change_health/compare/v4.8.0...v4.9.0
+[4.10.0]: https://github.com/WeInfuse/change_health/compare/v4.9.0...v4.10.0
+[4.9.0]: https://github.com/WeInfuse/change_health/compare/v4.8.0...v4.9.0
 [4.8.0]: https://github.com/WeInfuse/change_health/compare/v4.7.0...v4.8.0
 [4.7.0]: https://github.com/WeInfuse/change_health/compare/v4.6.0...v4.7.0
 [4.6.0]: https://github.com/WeInfuse/change_health/compare/v4.5.0...v4.6.0

--- a/lib/change_health/request/report.rb
+++ b/lib/change_health/request/report.rb
@@ -7,29 +7,41 @@ module ChangeHealth
 
         def self.report_list(headers: nil)
           final_headers = ChangeHealth::Request::Claim::Report.report_headers(headers)
-          ChangeHealth::Response::Claim::ReportListData.new(response: ChangeHealth::Connection.new.request(endpoint: ENDPOINT, verb: :get, headers: final_headers))
+          ChangeHealth::Response::Claim::ReportListData.new(response: ChangeHealth::Connection.new.request(
+            endpoint: ENDPOINT, verb: :get, headers: final_headers
+          ))
         end
 
         def self.get_report(report_name, as_json_report: true, headers: nil)
           return if report_name.nil? || report_name.empty?
-          final_headers =  ChangeHealth::Request::Claim::Report.report_headers(headers)
 
-          report_type = ChangeHealth::Response::Claim::ReportData.report_type(report_name)
-          return if report_type.nil?
+          final_headers = ChangeHealth::Request::Claim::Report.report_headers(headers)
 
-          individual_report_endpoint = ENDPOINT + '/' + report_name
+          individual_report_endpoint = "#{ENDPOINT}/#{report_name}"
 
           # https://developers.changehealthcare.com/eligibilityandclaims/docs/what-file-types-does-this-api-get-from-the-mailbox
-          individual_report_endpoint += '/' + report_type if as_json_report
+          if as_json_report
+            report_type = ChangeHealth::Response::Claim::ReportData.report_type(report_name)
+            individual_report_endpoint += "/#{report_type}"
+          end
 
-          response = ChangeHealth::Connection.new.request(endpoint: individual_report_endpoint, verb: :get, headers: final_headers)
+          response = ChangeHealth::Connection.new.request(
+            endpoint: individual_report_endpoint,
+            verb: :get,
+            headers: final_headers
+          )
           if ChangeHealth::Response::Claim::ReportData.is_277?(report_name)
             ChangeHealth::Response::Claim::Report277Data
               .new(report_name,
                    as_json_report,
                    response: response)
-          else
+          elsif ChangeHealth::Response::Claim::ReportData.is_835?(report_name)
             ChangeHealth::Response::Claim::Report835Data
+              .new(report_name,
+                   as_json_report,
+                   response: response)
+          else
+            ChangeHealth::Response::Claim::ReportData
               .new(report_name,
                    as_json_report,
                    response: response)
@@ -41,17 +53,15 @@ module ChangeHealth
         end
 
         def self.ping
-          self.health_check
+          health_check
         end
 
         def self.report_headers(headers)
           if headers
             extra_headers = {}
-            extra_headers["X-CHC-Reports-Username"] = headers[:username]
-            extra_headers["X-CHC-Reports-Password"] = headers[:password]
+            extra_headers['X-CHC-Reports-Username'] = headers[:username]
+            extra_headers['X-CHC-Reports-Password'] = headers[:password]
             extra_headers
-          else
-            nil
           end
         end
       end

--- a/lib/change_health/version.rb
+++ b/lib/change_health/version.rb
@@ -1,3 +1,3 @@
 module ChangeHealth
-  VERSION = '4.9.0'.freeze
+  VERSION = '4.10.0'.freeze
 end

--- a/test/change_health/request/report_test.rb
+++ b/test/change_health/request/report_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class ReportTest < Minitest::Test
   describe 'report' do
     let(:claim_report) { ChangeHealth::Request::Claim::Report }
-    let(:report_headers) { {username: "HeyThere", password: "Bob"}}
+    let(:report_headers) { { username: 'HeyThere', password: 'Bob' } }
 
     describe '#health_check' do
       let(:response) { build_response(file: 'health_check.response.json') }
@@ -78,6 +78,26 @@ class ReportTest < Minitest::Test
 
         it 'returns report data' do
           assert_equal(@report_data.raw, @report_data.response.parsed_response)
+        end
+      end
+      describe 'non 277 or 835 report' do
+        let(:report_name) { 'AA000000.AA' }
+        let(:response) { build_response(file: "claim/report/report.#{report_name}.response.json") }
+        let(:report_list_endpoint) { ChangeHealth::Request::Claim::Report::ENDPOINT + "/#{report_name}" }
+
+        before do
+          stub_change_health(endpoint: report_list_endpoint, response: response, verb: :get)
+
+          @report_data = claim_report.get_report(report_name, as_json_report: false, headers: report_headers)
+        end
+
+        it 'calls report' do
+          assert_requested(@stub)
+        end
+
+        it 'returns report data' do
+          assert_equal(@report_data.raw, @report_data.response.parsed_response)
+          assert_equal('Some content', @report_data.raw['report_content'])
         end
       end
     end

--- a/test/samples/claim/report/report.AA000000.AA.response.json
+++ b/test/samples/claim/report/report.AA000000.AA.response.json
@@ -1,0 +1,8 @@
+{
+    "report_content": "Some content",
+    "meta": {
+        "applicationMode": "sandbox",
+        "senderId": "MN_WeInfuse_App",
+        "traceId": "5a8bfb13-a71b-5c2e-54a9-f31d7620c4f9"
+    }
+}


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/183866185)

We restricted ourselves to just pulling back 835 & 277 reports. Now will be able to pull back any kind of report

Why doesn't this PR include parsing any new kind of reports that can be pulled back? B/c the documentation on these kinds of reports is not public facing so I don't want to put parsing it in a public facing place