### PR TITLE
185893588 add institutional claim submission specific headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+# [4.13.1] - 2023-08-23
+
+### Fixed
+
+Added institional claim submission specific headers so that institutional claims that required headers will go through in production
+
 # [4.13.0] - 2023-08-11
 
 ### Added
@@ -519,6 +525,7 @@ Added the ability to hit professional claim submission API. For more details, se
 * Authentication
 * Configuration
 
+[4.13.1]: https://github.com/WeInfuse/change_health/compare/v4.13.0...v4.13.1
 [4.13.0]: https://github.com/WeInfuse/change_health/compare/v4.12.0...v4.13.0
 [4.12.0]: https://github.com/WeInfuse/change_health/compare/v4.11.0...v4.12.0
 [4.11.0]: https://github.com/WeInfuse/change_health/compare/v4.10.1...v4.11.0

--- a/lib/change_health/request/submission.rb
+++ b/lib/change_health/request/submission.rb
@@ -36,17 +36,25 @@ module ChangeHealth
         def submission(is_professional: true)
           endpoint = is_professional ? PROFESSIONAL_ENDPOINT : INSTITUTIONAL_ENDPOINT
           endpoint += SUBMISSION_SUFFIX
-          ChangeHealth::Response::Claim::SubmissionData.new(response: ChangeHealth::Connection.new.request(
-            endpoint: endpoint, body: to_h, headers: professional_headers
-          ))
+          ChangeHealth::Response::Claim::SubmissionData.new(
+            response: ChangeHealth::Connection.new.request(
+              endpoint: endpoint,
+              body: to_h,
+              headers: is_professional ? professional_headers : institutional_headers
+            )
+          )
         end
 
         def validation(is_professional: true)
           endpoint = is_professional ? PROFESSIONAL_ENDPOINT : INSTITUTIONAL_ENDPOINT
           endpoint += VALIDATION_SUFFIX
-          ChangeHealth::Response::Claim::SubmissionData.new(response: ChangeHealth::Connection.new.request(
-            endpoint: endpoint, body: to_h, headers: professional_headers
-          ))
+          ChangeHealth::Response::Claim::SubmissionData.new(
+            response: ChangeHealth::Connection.new.request(
+              endpoint: endpoint,
+              body: to_h,
+              headers: is_professional ? professional_headers : institutional_headers
+            )
+          )
         end
 
         def self.health_check(is_professional: true)
@@ -62,12 +70,23 @@ module ChangeHealth
         def professional_headers
           return unless self[:headers]
 
-          extra_headers = {}
-          extra_headers['X-CHC-ClaimSubmission-SubmitterId'] = self[:headers][:submitter_id]
-          extra_headers['X-CHC-ClaimSubmission-BillerId'] = self[:headers][:biller_id]
-          extra_headers['X-CHC-ClaimSubmission-Username'] = self[:headers][:username]
-          extra_headers['X-CHC-ClaimSubmission-Pwd'] = self[:headers][:password]
-          extra_headers
+          {
+            'X-CHC-ClaimSubmission-BillerId' => self[:headers][:biller_id],
+            'X-CHC-ClaimSubmission-Pwd' => self[:headers][:password],
+            'X-CHC-ClaimSubmission-SubmitterId' => self[:headers][:submitter_id],
+            'X-CHC-ClaimSubmission-Username' => self[:headers][:username]
+          }
+        end
+
+        def institutional_headers
+          return unless self[:headers]
+
+          {
+            'X-CHC-InstitutionalClaims-BillerId' => self[:headers][:biller_id],
+            'X-CHC-InstitutionalClaims-Pwd' => self[:headers][:password],
+            'X-CHC-InstitutionalClaims-SubmitterId' => self[:headers][:submitter_id],
+            'X-CHC-InstitutionalClaims-Username' => self[:headers][:username]
+          }
         end
       end
     end

--- a/lib/change_health/version.rb
+++ b/lib/change_health/version.rb
@@ -1,3 +1,3 @@
 module ChangeHealth
-  VERSION = '4.13.0'.freeze
+  VERSION = '4.13.1'.freeze
 end

--- a/test/change_health/request/submission_test.rb
+++ b/test/change_health/request/submission_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class SubmissionTest < Minitest::Test
   describe 'claim_submission' do
-    let(:professional_headers) do
+    let(:headers) do
       {
         submitter_id: 'submittedIdValue',
         biller_id: 'billerIdValue',
@@ -10,7 +10,7 @@ class SubmissionTest < Minitest::Test
         password: 'passwordValue'
       }
     end
-    let(:claim_submission) { ChangeHealth::Request::Claim::Submission.new(headers: professional_headers) }
+    let(:claim_submission) { ChangeHealth::Request::Claim::Submission.new(headers: headers) }
 
     let(:professional_endpoint) { ChangeHealth::Request::Claim::Submission::PROFESSIONAL_ENDPOINT }
     let(:institutional_endpoint) { ChangeHealth::Request::Claim::Submission::INSTITUTIONAL_ENDPOINT }
@@ -145,6 +145,38 @@ class SubmissionTest < Minitest::Test
 
           it 'returns claim_submission data' do
             assert_equal(@submission_data.raw, @submission_data.response.parsed_response)
+          end
+        end
+
+        describe 'headers' do
+          describe 'professional' do
+            it 'given headers' do
+              expected = {
+                'X-CHC-ClaimSubmission-BillerId' => 'billerIdValue',
+                'X-CHC-ClaimSubmission-Pwd' => 'passwordValue',
+                'X-CHC-ClaimSubmission-SubmitterId' => 'submittedIdValue',
+                'X-CHC-ClaimSubmission-Username' => 'usernameValue'
+              }
+              assert_equal(expected, claim_submission.professional_headers)
+            end
+            it 'no headers' do
+              assert_nil(ChangeHealth::Request::Claim::Submission.new.professional_headers)
+            end
+          end
+
+          describe 'institutional' do
+            it 'given headers' do
+              expected = {
+                'X-CHC-InstitutionalClaims-BillerId' => 'billerIdValue',
+                'X-CHC-InstitutionalClaims-Pwd' => 'passwordValue',
+                'X-CHC-InstitutionalClaims-SubmitterId' => 'submittedIdValue',
+                'X-CHC-InstitutionalClaims-Username' => 'usernameValue'
+              }
+              assert_equal(expected, claim_submission.institutional_headers)
+            end
+            it 'no headers' do
+              assert_nil(ChangeHealth::Request::Claim::Submission.new.institutional_headers)
+            end
           end
         end
       end


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/185893588)

Turns out institutional & professional claim submission use 2 different sets of headers