### PR TITLE
DSeow/Demo Project Identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+# [5.4.2] - 2023-10-31
+
+### Added
+
+* Added demoProjectIdentifier attribute to ChangeHealth::Models::Claim::ClaimSupplementalInformation
+
 # [5.4.1] - 2023-10-30
 
 ### Added
@@ -593,6 +599,7 @@ Added the ability to hit professional claim submission API. For more details, se
 * Authentication
 * Configuration
 
+[5.4.2]: https://github.com/WeInfuse/change_health/compare/v5.4.1...v5.4.2
 [5.4.1]: https://github.com/WeInfuse/change_health/compare/v5.4.0...v5.4.1
 [5.4.0]: https://github.com/WeInfuse/change_health/compare/v5.3.1...v5.4.0
 [5.3.1]: https://github.com/WeInfuse/change_health/compare/v5.3.0...v5.3.1

--- a/README.md
+++ b/README.md
@@ -363,6 +363,14 @@ claim_submission = ChangeHealth::Request::Claim::Submission.new(
   billing_pay_to_address_name: billing_pay_to_address_name
 )
 
+claim_supplemental_information = ChangeHealth::Models::Claim::ClaimSupplementalInformation.new(
+  claim_control_number: 'claimControlNumber',
+  demo_project_identifier: 'demoProjectIdentifier',
+  prior_authorization_number: 'priorAuthorizationNumber',
+  referral_number: 'referralNumber',
+  report_information: 'reportInformation'
+)
+
 claim_submission_data = claim_submission.submission(is_professional: false)
 
 validation = claim_submission.validation(is_professional: false)

--- a/lib/change_health/models/claim/submission/claim_supplemental_information.rb
+++ b/lib/change_health/models/claim/submission/claim_supplemental_information.rb
@@ -3,6 +3,7 @@ module ChangeHealth
     module Claim
       class ClaimSupplementalInformation < Model
         property :claimControlNumber, from: :claim_control_number
+        property :demoProjectIdentifier, from: :demo_project_identifier
         property :priorAuthorizationNumber, from: :prior_authorization_number
         property :referralNumber, from: :referral_number
         property :reportInformation, from: :report_information

--- a/lib/change_health/version.rb
+++ b/lib/change_health/version.rb
@@ -1,3 +1,3 @@
 module ChangeHealth
-  VERSION = '5.4.1'.freeze
+  VERSION = '5.4.2'.freeze
 end


### PR DESCRIPTION
- Adds an attribute for `demo_project_identifier` in `ChangeHealth::Models::Claim::ClaimSupplementalInformation` because insurance needs more new info 🙄 