### PR TITLE
arodriguez/Patch ChangeHealth::Response::Error#retryable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+# [5.8.1] - 2024-04-01
+
+### Fixed
+
+ChangeHealth::Response::Error is retryable for retryable codes that do not have a followup action.
+Previously, a followup action was required to be retryable.
+
 # [5.8.0] - 2024-03-25
 
 ### Added
@@ -625,6 +632,7 @@ Added the ability to hit professional claim submission API. For more details, se
 * Authentication
 * Configuration
 
+[5.8.1]: https://github.com/WeInfuse/change_health/compare/v5.8.0...v5.8.1
 [5.8.0]: https://github.com/WeInfuse/change_health/compare/v5.7.0...v5.8.0
 [5.7.0]: https://github.com/WeInfuse/change_health/compare/v5.6.0...v5.7.0
 [5.6.0]: https://github.com/WeInfuse/change_health/compare/v5.5.0...v5.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-# [5.8.1] - 2024-04-01
+# [5.8.1] - 2024-04-02
 
 ### Fixed
 

--- a/lib/change_health/response/error.rb
+++ b/lib/change_health/response/error.rb
@@ -39,9 +39,7 @@ module ChangeHealth
 
       def retryable?
         represents_down? ||
-          (code? && SIMPLE_RETRY_CODES.include?(code) && followupAction? && NO_RESUBMIT_MESSAGES.none? do |msg|
-             followupAction.downcase.include?(msg)
-           end)
+          (code? && SIMPLE_RETRY_CODES.include?(code) && can_follow_up?)
       end
 
       %w[field description code followupAction location].each do |method_name|
@@ -51,6 +49,16 @@ module ChangeHealth
 
         define_method(method_name.to_s) do
           @data[method_name]
+        end
+      end
+
+      private
+
+      def can_follow_up?
+        return true if followupAction.nil? || followupAction.empty?
+
+        followupAction? && NO_RESUBMIT_MESSAGES.none? do |msg|
+          followupAction.downcase.include?(msg)
         end
       end
     end

--- a/lib/change_health/version.rb
+++ b/lib/change_health/version.rb
@@ -1,3 +1,3 @@
 module ChangeHealth
-  VERSION = '5.8.0'.freeze
+  VERSION = '5.8.1'.freeze
 end


### PR DESCRIPTION
Previously, `ChangeHealth::Response::Error#retryable` returned `false` for errors that do not include a `followupAction`.
For example:
```json
"errors": [
  {
    "field": "AAA",
    "description": "Unable to respond at current time, payer gateway is not available",
    "code": "42",
    "location": null
  }
]
```
This patch fixes retryable to be true if there is no followupAction for a retryable code.