### PR TITLE
187483988 support new date format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+# [5.10.0] - 2024-04-23
+
+### Added
+
+* Support date format YYYY-MM-DD
+
 # [5.9.0] - 2024-04-19
 
 ### Added
@@ -638,6 +644,7 @@ Added the ability to hit professional claim submission API. For more details, se
 * Authentication
 * Configuration
 
+[5.10.0]: https://github.com/WeInfuse/change_health/compare/v5.9.0...v5.10.0
 [5.9.0]: https://github.com/WeInfuse/change_health/compare/v5.8.1...v5.9.0
 [5.8.1]: https://github.com/WeInfuse/change_health/compare/v5.8.0...v5.8.1
 [5.8.0]: https://github.com/WeInfuse/change_health/compare/v5.7.0...v5.8.0

--- a/lib/change_health/models/model.rb
+++ b/lib/change_health/models/model.rb
@@ -34,7 +34,7 @@ module ChangeHealth
 
     PARSE_DATE = lambda { |d|
       begin
-        d = Date.strptime(d, ChangeHealth::Models::DATE_FORMAT)
+        d = Date.strptime(d.tr('-', ''), ChangeHealth::Models::DATE_FORMAT)
       rescue StandardError
       end
 

--- a/lib/change_health/version.rb
+++ b/lib/change_health/version.rb
@@ -1,3 +1,3 @@
 module ChangeHealth
-  VERSION = '5.9.0'.freeze
+  VERSION = '5.10.0'.freeze
 end

--- a/test/change_health/models/model_test.rb
+++ b/test/change_health/models/model_test.rb
@@ -101,6 +101,12 @@ class ModelTest < Minitest::Test
         assert_equal(Date.new(2016, 9, 15), ChangeHealth::Models::PARSE_DATE.call('20160915'))
       end
 
+      it 'handles alternate format' do
+        assert_equal(Date.new(2012, 5, 1), ChangeHealth::Models::PARSE_DATE.call('2012-05-01'))
+        assert_equal(Date.new(2015, 1, 1), ChangeHealth::Models::PARSE_DATE.call('2015-01-01'))
+        assert_equal(Date.new(2016, 9, 15), ChangeHealth::Models::PARSE_DATE.call('2016-09-15'))
+      end
+
       it 'returns input if bad date format' do
         fake_date_string = 'lskjdf'
         assert_equal(fake_date_string, ChangeHealth::Models::PARSE_DATE.call(fake_date_string))

--- a/test/change_health/models/model_test.rb
+++ b/test/change_health/models/model_test.rb
@@ -105,6 +105,7 @@ class ModelTest < Minitest::Test
         assert_equal(Date.new(2012, 5, 1), ChangeHealth::Models::PARSE_DATE.call('2012-05-01'))
         assert_equal(Date.new(2015, 1, 1), ChangeHealth::Models::PARSE_DATE.call('2015-01-01'))
         assert_equal(Date.new(2016, 9, 15), ChangeHealth::Models::PARSE_DATE.call('2016-09-15'))
+        assert_equal(Date.new(2016, 9, 15), ChangeHealth::Models::PARSE_DATE.call('20-1-6-09----1--5'))
       end
 
       it 'returns input if bad date format' do


### PR DESCRIPTION
Previously only supported dates being `YYYYMMDD`. Now support dates being `YYYY-MM-DD`. Honestly, also `Y---Y--Y-Y------MMD---D`. Any amount of `-`