### PR TITLE
Add orderingProvider to ServiceLine (#187391454)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -650,6 +650,7 @@ Added the ability to hit professional claim submission API. For more details, se
 * Authentication
 * Configuration
 
+[5.11.0]: https://github.com/WeInfuse/change_health/compare/v5.10.0...v5.11.0
 [5.10.0]: https://github.com/WeInfuse/change_health/compare/v5.9.0...v5.10.0
 [5.9.0]: https://github.com/WeInfuse/change_health/compare/v5.8.1...v5.9.0
 [5.8.1]: https://github.com/WeInfuse/change_health/compare/v5.8.0...v5.8.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+# [6.0.0] - 2024-04-23
+
+### Added
+
+* orderingProvider to ChangeHealth::Models::Claim::ServiceLine
+
 # [5.9.0] - 2024-04-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-# [6.0.0] - 2024-04-23
+# [5.11.0] - 2024-04-23
 
 ### Added
 

--- a/lib/change_health/models/claim/submission/service_line.rb
+++ b/lib/change_health/models/claim/submission/service_line.rb
@@ -6,6 +6,7 @@ module ChangeHealth
         property :drugIdentification, from: :drug_identification
         property :institutionalService, from: :institutional_service
         property :lineAdjudicationInformation, from: :line_adjudication_information
+        property :orderingProvider, from: :ordering_provider
         property :professionalService, from: :professional_service
         property :renderingProvider, from: :rendering_provider
         property :serviceDate, from: :service_date

--- a/lib/change_health/version.rb
+++ b/lib/change_health/version.rb
@@ -1,3 +1,3 @@
 module ChangeHealth
-  VERSION = '5.10.0'.freeze
+  VERSION = '5.11.0'.freeze
 end

--- a/lib/change_health/version.rb
+++ b/lib/change_health/version.rb
@@ -1,3 +1,3 @@
 module ChangeHealth
-  VERSION = '5.9.0'.freeze
+  VERSION = '6.0.0'.freeze
 end


### PR DESCRIPTION
Adds orderingProvider field to ServiceLine, which is needed to support the latest spec.