### PR TITLE
187583733 ignore empty but not nil values for claim report data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+# [5.12.1] - 2024-05-10
+
+### Fixed
+
+* For ChangeHealth::Response::Claim::ReportData, if multiple json values can be used to find a value, it will now use other json values if the first choice is empty but not nil like `""`
+
 # [5.12.0] - 2024-04-26
 
 ### Added
@@ -656,6 +662,7 @@ Added the ability to hit professional claim submission API. For more details, se
 * Authentication
 * Configuration
 
+[5.12.1]: https://github.com/WeInfuse/change_health/compare/v5.12.0...v5.12.1
 [5.12.0]: https://github.com/WeInfuse/change_health/compare/v5.11.0...v5.12.0
 [5.11.0]: https://github.com/WeInfuse/change_health/compare/v5.10.0...v5.11.0
 [5.10.0]: https://github.com/WeInfuse/change_health/compare/v5.9.0...v5.10.0

--- a/lib/change_health/response/claim/report/report_277_data.rb
+++ b/lib/change_health/response/claim/report/report_277_data.rb
@@ -44,8 +44,8 @@ module ChangeHealth
                       referenced_transaction_trace_number = claim_status['referencedTransactionTraceNumber']
                       trading_partner_claim_number = claim_status['tradingPartnerClaimNumber']
 
-                      service_date_begin = ChangeHealth::Models::PARSE_DATE.call(claim_status['claimServiceBeginDate'] || claim_status['claimServiceDate'])
-                      service_date_end = ChangeHealth::Models::PARSE_DATE.call(claim_status['claimServiceEndDate'] || claim_status['claimServiceDate'])
+                      service_date_begin = ChangeHealth::Models::PARSE_DATE.call(presence(claim_status['claimServiceBeginDate']) || presence(claim_status['claimServiceDate']))
+                      service_date_end = ChangeHealth::Models::PARSE_DATE.call(presence(claim_status['claimServiceEndDate']) || presence(claim_status['claimServiceDate']))
 
                       info_claim_statuses = []
                       claim_status['informationClaimStatuses']&.each do |info_claim_status|

--- a/lib/change_health/response/claim/report/report_835_data.rb
+++ b/lib/change_health/response/claim/report/report_835_data.rb
@@ -62,13 +62,13 @@ module ChangeHealth
                 patient_first_name = payment_info.dig('patientName', 'firstName')
                 patient_last_name = payment_info.dig('patientName', 'lastName')
                 patient_member_id =
-                  payment_info.dig('patientName', 'memberId') ||
-                  payment_info.dig('subscriber', 'memberId')
+                  presence(payment_info.dig('patientName', 'memberId')) ||
+                  presence(payment_info.dig('subscriber', 'memberId'))
                 payer_claim_control_number = payment_info.dig('claimPaymentInfo', 'payerClaimControlNumber')
                 service_provider_npi =
-                  payment_info.dig('renderingProvider', 'npi') ||
-                  detail_info.dig('providerSummaryInformation', 'providerIdentifier') ||
-                  transaction.dig('payee', 'npi')
+                  presence(payment_info.dig('renderingProvider', 'npi')) ||
+                  presence(detail_info.dig('providerSummaryInformation', 'providerIdentifier')) ||
+                  presence(transaction.dig('payee', 'npi'))
                 total_charge_amount = payment_info.dig('claimPaymentInfo', 'totalClaimChargeAmount')
 
                 claim_payment_remark_codes = []

--- a/lib/change_health/response/claim/report/report_data.rb
+++ b/lib/change_health/response/claim/report/report_data.rb
@@ -3,7 +3,7 @@ module ChangeHealth
     module Claim
       class ReportData < ChangeHealth::Response::ResponseData
         attr_reader :report_name, :json
-        alias_method :json?, :json
+        alias json? json
 
         def initialize(report_name, json, data: nil, response: nil)
           super(data: data, response: response)
@@ -38,6 +38,11 @@ module ChangeHealth
 
         def self.is_835?(report_name)
           report_name.start_with?('R5')
+        end
+
+        # Ripped from rails Object#presence method
+        def presence(obj)
+          obj unless obj.respond_to?(:empty?) ? !!obj.empty? : !obj
         end
       end
     end

--- a/lib/change_health/version.rb
+++ b/lib/change_health/version.rb
@@ -1,3 +1,3 @@
 module ChangeHealth
-  VERSION = '5.12.0'.freeze
+  VERSION = '5.12.1'.freeze
 end

--- a/test/change_health/response/claim/report/report_data_test.rb
+++ b/test/change_health/response/claim/report/report_data_test.rb
@@ -31,4 +31,36 @@ class ReportDataTest < Minitest::Test
       assert report_data_edi.edi?
     end
   end
+
+  describe 'utility methods' do
+    let(:report_data) { ChangeHealth::Response::Claim::ReportData.new('name', {}) }
+
+    describe 'presence' do
+      it 'uses empty and is not present' do
+        x = []
+        assert_equal true, x.empty?
+        assert_nil report_data.presence(x)
+      end
+
+      it 'uses empty and is present' do
+        x = [1, 2, 3]
+        assert_equal false, x.empty?
+        assert_equal x, report_data.presence(x)
+      end
+
+      it 'does not use empty and is not present' do
+        x = false
+
+        assert_equal false, x.respond_to?(:empty?)
+        assert_nil report_data.presence(x)
+      end
+
+      it 'does not use empty and is present' do
+        x = true
+
+        assert_equal false, x.respond_to?(:empty?)
+        assert_equal x, report_data.presence(x)
+      end
+    end
+  end
 end

--- a/test/samples/claim/report/report.R5000000.WC.json.response.json
+++ b/test/samples/claim/report/report.R5000000.WC.json.response.json
@@ -877,6 +877,9 @@
             "detailInfo": [
                 {
                     "assignedNumber": "1",
+                    "providerSummaryInformation": {
+                        "providerIdentifier": ""
+                    },
                     "paymentInfo": [
                         {
                             "claimPaymentInfo": {


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/187583733)

Sometimes we get back a field like this: `patientName: ''` and we want to ignore that and look at other fields. But `"" || "something"` is `""` so we need a bit more than just `||`