### PR TITLE
187612421 Ignore completely empty adjustments in claim report 835s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+# [5.13.2] - 2024-05-16
+
+### Fixed
+
+* For ChangeHealth::Response::Claim::Report835Data, the following lists of values will now ignore empty "" in the json, even if the WHOLE field is empty
+- claim_payment_remark_codes
+- claim_adjustments
+- service_adjustments
+
 # [5.13.1] - 2024-05-15
 
 ### Fixed
@@ -677,6 +686,7 @@ Added the ability to hit professional claim submission API. For more details, se
 * Authentication
 * Configuration
 
+[5.13.2]: https://github.com/WeInfuse/change_health/compare/v5.13.1...v5.13.2
 [5.13.1]: https://github.com/WeInfuse/change_health/compare/v5.13.0...v5.13.1
 [5.13.0]: https://github.com/WeInfuse/change_health/compare/v5.12.1...v5.13.0
 [5.12.1]: https://github.com/WeInfuse/change_health/compare/v5.12.0...v5.12.1

--- a/lib/change_health/version.rb
+++ b/lib/change_health/version.rb
@@ -1,3 +1,3 @@
 module ChangeHealth
-  VERSION = '5.13.1'.freeze
+  VERSION = '5.13.2'.freeze
 end

--- a/test/change_health/response/claim/report/report_835_data_test.rb
+++ b/test/change_health/response/claim/report/report_835_data_test.rb
@@ -179,6 +179,24 @@ class Report835DataTest < Minitest::Test
           assert_equal Date.new(2019, 3, 23), odd_claim_service_date.service_date_begin
           assert_equal Date.new(2019, 3, 24), odd_claim_service_date.service_date_end
         end
+
+        describe 'all blank adjustments' do
+          it 'claimPaymentRemarkCodes' do
+            assert_equal [], odd_claim1.claim_payment_remark_codes
+          end
+
+          it 'claimAdjustments' do
+            assert_nil odd_claim1.claim_adjustments
+          end
+
+          it 'serviceAdjustments' do
+            assert_nil odd_claim1.service_lines[0].service_adjustments
+          end
+
+          it 'healthCareCheckRemarkCodes' do
+            assert_nil odd_claim1.service_lines[0].health_care_check_remark_codes
+          end
+        end
       end
     end
   end

--- a/test/samples/claim/report/report.R5000000.WC.json.response.json
+++ b/test/samples/claim/report/report.R5000000.WC.json.response.json
@@ -143,6 +143,11 @@
                                             "codeListQualifierCode": "HE",
                                             "codeListQualifierCodeValue": "Claim Payment Remark Codes",
                                             "remarkCode": "N510"
+                                        },
+                                        {
+                                            "codeListQualifierCode": "HE",
+                                            "codeListQualifierCodeValue": "Claim Payment Remark Codes",
+                                            "remarkCode": ""
                                         }
                                     ]
                                 },
@@ -651,6 +656,37 @@
                             "claimSupplementalInformation": {
                                 "coverageAmount": "28"
                             },
+                            "outpatientAdjudication": {
+                                "claimPaymentRemarkCode1": "",
+                                "claimPaymentRemarkCode2": "",
+                                "claimPaymentRemarkCode3": "",
+                                "claimPaymentRemarkCode4": "",
+                                "claimPaymentRemarkCode5": ""
+                            },
+                            "claimAdjustments": [
+                                {
+                                    "claimAdjustmentGroupCode": "",
+                                    "claimAdjustmentGroupCodeValue": "",
+                                    "adjustmentReasonCode1": "",
+                                    "adjustmentAmount1": "",
+                                    "adjustmentQuantity1": "",
+                                    "adjustmentReasonCode2": "",
+                                    "adjustmentAmount2": "",
+                                    "adjustmentQuantity2": "",
+                                    "adjustmentReasonCode3": "",
+                                    "adjustmentAmount3": "",
+                                    "adjustmentQuantity3": "",
+                                    "adjustmentReasonCode4": "",
+                                    "adjustmentAmount4": "",
+                                    "adjustmentQuantity4": "",
+                                    "adjustmentReasonCode5": "",
+                                    "adjustmentAmount5": "",
+                                    "adjustmentQuantity5": "",
+                                    "adjustmentReasonCode6": "",
+                                    "adjustmentAmount6": "",
+                                    "adjustmentQuantity6": ""
+                                }
+                            ],
                             "serviceLines": [
                                 {
                                     "serviceDate": "20190313",
@@ -663,10 +699,60 @@
                                     },
                                     "serviceAdjustments": [
                                         {
-                                            "claimAdjustmentGroupCode": "CO",
-                                            "claimAdjustmentGroupCodeValue": "Contractual Obligations",
-                                            "adjustmentReasonCode1": "45",
-                                            "adjustmentAmount1": "125"
+                                            "claimAdjustmentGroupCode": "",
+                                            "claimAdjustmentGroupCodeValue": "",
+                                            "adjustmentReasonCode1": "",
+                                            "adjustmentAmount1": "",
+                                            "adjustmentQuantity1": "",
+                                            "adjustmentReasonCode2": "",
+                                            "adjustmentAmount2": "",
+                                            "adjustmentQuantity2": "",
+                                            "adjustmentReasonCode3": "",
+                                            "adjustmentAmount3": "",
+                                            "adjustmentQuantity3": "",
+                                            "adjustmentReasonCode4": "",
+                                            "adjustmentAmount4": "",
+                                            "adjustmentQuantity4": "",
+                                            "adjustmentReasonCode5": "",
+                                            "adjustmentAmount5": "",
+                                            "adjustmentQuantity5": "",
+                                            "adjustmentReasonCode6": "",
+                                            "adjustmentAmount6": "",
+                                            "adjustmentQuantity6": ""
+                                        },
+                                        {
+                                            "claimAdjustmentGroupCode": "",
+                                            "claimAdjustmentGroupCodeValue": "",
+                                            "adjustmentReasonCode1": "",
+                                            "adjustmentAmount1": "",
+                                            "adjustmentQuantity1": "",
+                                            "adjustmentReasonCode2": "",
+                                            "adjustmentAmount2": "",
+                                            "adjustmentQuantity2": "",
+                                            "adjustmentReasonCode3": "",
+                                            "adjustmentAmount3": "",
+                                            "adjustmentQuantity3": "",
+                                            "adjustmentReasonCode4": "",
+                                            "adjustmentAmount4": "",
+                                            "adjustmentQuantity4": "",
+                                            "adjustmentReasonCode5": "",
+                                            "adjustmentAmount5": "",
+                                            "adjustmentQuantity5": "",
+                                            "adjustmentReasonCode6": "",
+                                            "adjustmentAmount6": "",
+                                            "adjustmentQuantity6": ""
+                                        }
+                                    ],
+                                    "healthCareCheckRemarkCodes": [
+                                        {
+                                            "codeListQualifierCode": "HE",
+                                            "codeListQualifierCodeValue": "Claim Payment Remark Codes",
+                                            "remarkCode": ""
+                                        },
+                                        {
+                                            "codeListQualifierCode": "HE",
+                                            "codeListQualifierCodeValue": "Claim Payment Remark Codes",
+                                            "remarkCode": ""
                                         }
                                     ]
                                 },


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/187612421)

[Previous PR](https://github.com/WeInfuse/change_health/pull/90) where I missed the use care of a field having absolutely NO values

The test json file shows best what is now accommodated