### PR TITLE
187636358 fix where id is grabbed for claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+# [5.13.3] - 2024-05-20
+
+### Fixed
+
+* Grab "id" per claim for ChangeHealth::Response::Claim::Report835Claim INSTEAD of per transaction. B/c each transaction is a payment, not a claim
+
 # [5.13.2] - 2024-05-16
 
 ### Fixed
@@ -686,6 +692,7 @@ Added the ability to hit professional claim submission API. For more details, se
 * Authentication
 * Configuration
 
+[5.13.3]: https://github.com/WeInfuse/change_health/compare/v5.13.2...v5.13.3
 [5.13.2]: https://github.com/WeInfuse/change_health/compare/v5.13.1...v5.13.2
 [5.13.1]: https://github.com/WeInfuse/change_health/compare/v5.13.0...v5.13.1
 [5.13.0]: https://github.com/WeInfuse/change_health/compare/v5.12.1...v5.13.0

--- a/lib/change_health/response/claim/report/report_835_data.rb
+++ b/lib/change_health/response/claim/report/report_835_data.rb
@@ -28,7 +28,7 @@ module ChangeHealth
           report_payments = []
 
           transactions&.each do |transaction|
-            id = transaction.dig('id')
+            payment_id = transaction.dig('id')
             check_or_eft_trace_number = transaction.dig('paymentAndRemitReassociationDetails', 'checkOrEFTTraceNumber')
             check_issue_or_eft_effective_date =
               ChangeHealth::Models::PARSE_DATE.call(
@@ -56,6 +56,7 @@ module ChangeHealth
             total_actual_provider_payment_amount =
               transaction.dig('financialInformation', 'totalActualProviderPaymentAmount')
             claims = transaction['detailInfo']&.flat_map do |detail_info|
+              claim_id = detail_info.dig('id')
               detail_info['paymentInfo']&.map do |payment_info|
                 claim_payment_amount = payment_info.dig('claimPaymentInfo', 'claimPaymentAmount')
                 claim_status_code = payment_info.dig('claimPaymentInfo', 'claimStatusCode')
@@ -141,7 +142,7 @@ module ChangeHealth
                   claim_payment_amount: claim_payment_amount,
                   claim_payment_remark_codes: claim_payment_remark_codes,
                   claim_status_code: claim_status_code,
-                  id: id,
+                  id: claim_id,
                   patient_control_number: patient_control_number,
                   patient_first_name: patient_first_name,
                   patient_last_name: patient_last_name,
@@ -163,7 +164,7 @@ module ChangeHealth
               check_issue_or_eft_effective_date: check_issue_or_eft_effective_date,
               check_or_eft_trace_number: check_or_eft_trace_number,
               claims: claims,
-              id: id,
+              id: payment_id,
               payer_identifier: payer_identifier,
               payer_name: payer_name,
               payer_address: payer_address,

--- a/lib/change_health/version.rb
+++ b/lib/change_health/version.rb
@@ -1,3 +1,3 @@
 module ChangeHealth
-  VERSION = '5.13.2'.freeze
+  VERSION = '5.13.3'.freeze
 end

--- a/test/change_health/response/claim/report/report_835_data_test.rb
+++ b/test/change_health/response/claim/report/report_835_data_test.rb
@@ -37,6 +37,7 @@ class Report835DataTest < Minitest::Test
         }
         assert_equal Date.new(2019, 3, 31), actual_payment.check_issue_or_eft_effective_date
         assert_equal '12345', actual_payment.check_or_eft_trace_number
+        assert_equal '3029342309', actual_payment.id
         assert_equal '1351840597', actual_payment.payer_identifier
         assert_equal address[:address1], actual_payment.payer_address['address1']
         assert_equal 'DENTAL OF ABC', actual_payment.payer_name
@@ -86,11 +87,18 @@ class Report835DataTest < Minitest::Test
           claim_adjustment_group_code: 'OA'
         )
 
-        health_care_check_remark_codes = [ChangeHealth::Response::Claim::Report835HealthCareCheckRemarkCode.new(
-          code_list_qualifier_code: 'HE',
-          code_list_qualifier_code_value: 'Claim Payment Remark Codes',
-          remark_code: 'N510'
-        )]
+        health_care_check_remark_codes = [
+          ChangeHealth::Response::Claim::Report835HealthCareCheckRemarkCode.new(
+            code_list_qualifier_code: 'HE',
+            code_list_qualifier_code_value: 'Claim Payment Remark Codes',
+            remark_code: 'N510'
+          ),
+          ChangeHealth::Response::Claim::Report835HealthCareCheckRemarkCode.new(
+            code_list_qualifier_code: 'HE',
+            code_list_qualifier_code_value: 'Claim Payment Remark Codes',
+            remark_code: 'N381'
+          )
+        ]
 
         service_lines = []
         service_lines << ChangeHealth::Response::Claim::Report835ServiceLine.new(

--- a/test/samples/claim/report/report.R5000000.WC.json.response.json
+++ b/test/samples/claim/report/report.R5000000.WC.json.response.json
@@ -1,7 +1,7 @@
 {
     "transactions": [
         {
-            "id": "84298742037",
+            "id": "3029342309",
             "controlNumber": "35681",
             "paymentAndRemitReassociationDetails": {
                 "traceTypeCode": "1",
@@ -45,6 +45,7 @@
             },
             "detailInfo": [
                 {
+                    "id": "84298742037",
                     "assignedNumber": "1",
                     "paymentInfo": [
                         {
@@ -143,6 +144,11 @@
                                             "codeListQualifierCode": "HE",
                                             "codeListQualifierCodeValue": "Claim Payment Remark Codes",
                                             "remarkCode": "N510"
+                                        },
+                                        {
+                                            "codeListQualifierCode": "HE",
+                                            "codeListQualifierCodeValue": "Claim Payment Remark Codes",
+                                            "remarkCode": "N381"
                                         },
                                         {
                                             "codeListQualifierCode": "HE",
@@ -583,7 +589,7 @@
             ]
         },
         {
-            "id": "823947293874",
+            "id": "39293473",
             "controlNumber": "234",
             "paymentAndRemitReassociationDetails": {
                 "traceTypeCode": "1",
@@ -627,6 +633,7 @@
             },
             "detailInfo": [
                 {
+                    "id": "823947293874",
                     "assignedNumber": "1",
                     "providerSummaryInformation": {
                         "providerIdentifier": "1811901928"


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/187636358)

Grab "id" per claim for ChangeHealth::Response::Claim::Report835Claim INSTEAD of per transaction. B/c each transaction is a payment, not a claim