### PR TITLE
Allow for per request configuration for report requests (#187668040)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-* The following report endpoints can override the base URI and authentication headers per request if needed:
+* The following report methods can override the base URI, endpoint, and authentication headers per request if needed:
   - `ChangeHealth::Request::Claim::Report.report_list`
   - `ChangeHealth::Request::Claim::Report.get_report`
   - `ChangeHealth::Request::Claim::Report.delete_report`
 
   Provide the following parameters to override the defaults set in Configuration:
   - `base_uri`
+  - `endpoint`
   - `auth_headers` - an empty hash can also be provided (`{}`), which will issue a request to the authentication endpoint instead of using the configured headers.
 
 # [5.13.3] - 2024-05-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-# [5.13.4] - 2024-06-11
+# [5.14.0] - 2024-06-11
 
 ### Added
 
@@ -706,7 +706,7 @@ Added the ability to hit professional claim submission API. For more details, se
 * Authentication
 * Configuration
 
-[5.13.4]: https://github.com/WeInfuse/change_health/compare/v5.13.3...v5.13.4
+[5.14.0]: https://github.com/WeInfuse/change_health/compare/v5.13.3...v5.14.0
 [5.13.3]: https://github.com/WeInfuse/change_health/compare/v5.13.2...v5.13.3
 [5.13.2]: https://github.com/WeInfuse/change_health/compare/v5.13.1...v5.13.2
 [5.13.1]: https://github.com/WeInfuse/change_health/compare/v5.13.0...v5.13.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+# [5.13.4] - 2024-06-11
+
+### Added
+
+* The following report endpoints can override the base URI and authentication headers per request if needed:
+  - `ChangeHealth::Request::Claim::Report.report_list`
+  - `ChangeHealth::Request::Claim::Report.get_report`
+  - `ChangeHealth::Request::Claim::Report.delete_report`
+
+  Provide the following parameters to override the defaults set in Configuration:
+  - `base_uri`
+  - `auth_headers` - an empty hash can also be provided (`{}`), which will issue a request to the authentication endpoint instead of using the configured headers.
+
 # [5.13.3] - 2024-05-20
 
 ### Fixed
@@ -692,6 +705,7 @@ Added the ability to hit professional claim submission API. For more details, se
 * Authentication
 * Configuration
 
+[5.13.4]: https://github.com/WeInfuse/change_health/compare/v5.13.3...v5.13.4
 [5.13.3]: https://github.com/WeInfuse/change_health/compare/v5.13.2...v5.13.3
 [5.13.2]: https://github.com/WeInfuse/change_health/compare/v5.13.1...v5.13.2
 [5.13.1]: https://github.com/WeInfuse/change_health/compare/v5.13.0...v5.13.1

--- a/lib/change_health/authentication.rb
+++ b/lib/change_health/authentication.rb
@@ -9,14 +9,15 @@ module ChangeHealth
       @request_time = nil
     end
 
-    def authenticate
+    def authenticate(base_uri: nil)
       if (self.expires?)
+        base_uri ||= Connection.base_uri
         request = {
           body: { client_id: ChangeHealth.configuration.client_id, client_secret: ChangeHealth.configuration.client_secret, grant_type: ChangeHealth.configuration.grant_type },
           endpoint: AUTH_ENDPOINT
         }
 
-        response = Connection.new.request(**request, auth: false)
+        response = Connection.new.request(**request, auth: false, base_uri: base_uri)
 
         if (false == response.ok?)
           @response = nil

--- a/lib/change_health/connection.rb
+++ b/lib/change_health/connection.rb
@@ -26,7 +26,7 @@ module ChangeHealth
       base_uri ||= Connection.base_uri
       body    = body.to_json if body.is_a?(Hash)
       headers = {} if headers.nil?
-      headers = auth_header(auth_headers).merge(headers) if auth
+      headers = auth_header(base_uri: base_uri, auth_headers: auth_headers).merge(headers) if auth
 
       self.class.send(verb.to_s, endpoint, query: query, body: body, headers: headers, base_uri: base_uri)
     end
@@ -40,13 +40,13 @@ module ChangeHealth
 
     private
 
-    def auth_header(auth_headers = nil)
+    def auth_header(base_uri: nil, auth_headers: nil)
       auth_headers ||= ChangeHealth.configuration.auth_headers
 
       if auth_headers.nil? || auth_headers.empty?
         @auth ||= Authentication.new
 
-        @auth.authenticate.access_header
+        @auth.authenticate(base_uri: base_uri).access_header
       else
         auth_headers
       end

--- a/lib/change_health/connection.rb
+++ b/lib/change_health/connection.rb
@@ -13,12 +13,22 @@ module ChangeHealth
 
     format :json
 
-    def request(endpoint:, query: nil, body: nil, headers: {}, auth: true, verb: :post)
+    def request(
+      endpoint:,
+      query: nil,
+      body: nil,
+      headers: {},
+      auth: true,
+      verb: :post,
+      base_uri: nil,
+      auth_headers: nil
+    )
+      base_uri ||= Connection.base_uri
       body    = body.to_json if body.is_a?(Hash)
       headers = {} if headers.nil?
-      headers = auth_header.merge(headers) if auth
+      headers = auth_header(auth_headers).merge(headers) if auth
 
-      self.class.send(verb.to_s, endpoint, query: query, body: body, headers: headers)
+      self.class.send(verb.to_s, endpoint, query: query, body: body, headers: headers, base_uri: base_uri)
     end
 
     def self.endpoint_for(klass, default_endpoint: nil)
@@ -30,13 +40,15 @@ module ChangeHealth
 
     private
 
-    def auth_header
-      if ChangeHealth.configuration.auth_headers.nil?
+    def auth_header(auth_headers = nil)
+      auth_headers ||= ChangeHealth.configuration.auth_headers
+
+      if auth_headers.nil? || auth_headers.empty?
         @auth ||= Authentication.new
 
         @auth.authenticate.access_header
       else
-        ChangeHealth.configuration.auth_headers
+        auth_headers
       end
     end
   end

--- a/lib/change_health/request/report.rb
+++ b/lib/change_health/request/report.rb
@@ -5,11 +5,15 @@ module ChangeHealth
         ENDPOINT = '/medicalnetwork/reports/v2'.freeze
         HEALTH_CHECK_ENDPOINT = ENDPOINT + '/healthcheck'.freeze
 
-        def self.report_list(headers: nil, more_url: nil)
+        def self.report_list(headers: nil, more_url: nil, base_uri: nil, auth_headers: nil)
           endpoint = ChangeHealth::Connection.endpoint_for(self) + more_url.to_s
           final_headers = ChangeHealth::Request::Claim::Report.report_headers(headers)
           ChangeHealth::Response::Claim::ReportListData.new(response: ChangeHealth::Connection.new.request(
-            endpoint: endpoint, verb: :get, headers: final_headers
+            endpoint: endpoint,
+            verb: :get,
+            headers: final_headers,
+            base_uri: base_uri,
+            auth_headers: auth_headers
           ))
         end
 
@@ -17,7 +21,9 @@ module ChangeHealth
           report_name,
           as_json_report: true,
           headers: nil,
-          report_type: nil
+          report_type: nil,
+          base_uri: nil,
+          auth_headers: nil
         )
           return if report_name.nil? || report_name.empty?
 
@@ -38,7 +44,9 @@ module ChangeHealth
           response = ChangeHealth::Connection.new.request(
             endpoint: individual_report_endpoint,
             verb: :get,
-            headers: final_headers
+            headers: final_headers,
+            base_uri: base_uri,
+            auth_headers: auth_headers
           )
           if ChangeHealth::Response::Claim::ReportData.is_277?(report_name)
             ChangeHealth::Response::Claim::Report277Data
@@ -58,7 +66,7 @@ module ChangeHealth
           end
         end
 
-        def self.delete_report(report_name, headers: nil)
+        def self.delete_report(report_name, headers: nil, base_uri: nil, auth_headers: nil)
           return if report_name.nil? || report_name.empty?
 
           final_headers = ChangeHealth::Request::Claim::Report.report_headers(headers)
@@ -69,7 +77,9 @@ module ChangeHealth
           ChangeHealth::Connection.new.request(
             endpoint: individual_report_endpoint,
             verb: :delete,
-            headers: final_headers
+            headers: final_headers,
+            base_uri: base_uri,
+            auth_headers: auth_headers
           )
         end
 

--- a/lib/change_health/request/report.rb
+++ b/lib/change_health/request/report.rb
@@ -5,8 +5,9 @@ module ChangeHealth
         ENDPOINT = '/medicalnetwork/reports/v2'.freeze
         HEALTH_CHECK_ENDPOINT = ENDPOINT + '/healthcheck'.freeze
 
-        def self.report_list(headers: nil, more_url: nil, base_uri: nil, auth_headers: nil)
-          endpoint = ChangeHealth::Connection.endpoint_for(self) + more_url.to_s
+        def self.report_list(headers: nil, more_url: nil, base_uri: nil, endpoint: nil, auth_headers: nil)
+          endpoint ||= ChangeHealth::Connection.endpoint_for(self)
+          endpoint += more_url.to_s
           final_headers = ChangeHealth::Request::Claim::Report.report_headers(headers)
           ChangeHealth::Response::Claim::ReportListData.new(response: ChangeHealth::Connection.new.request(
             endpoint: endpoint,
@@ -23,13 +24,14 @@ module ChangeHealth
           headers: nil,
           report_type: nil,
           base_uri: nil,
+          endpoint: nil,
           auth_headers: nil
         )
           return if report_name.nil? || report_name.empty?
 
           final_headers = ChangeHealth::Request::Claim::Report.report_headers(headers)
 
-          endpoint = ChangeHealth::Connection.endpoint_for(self)
+          endpoint ||= ChangeHealth::Connection.endpoint_for(self)
 
           individual_report_endpoint = "#{endpoint}/#{report_name}"
 
@@ -66,12 +68,12 @@ module ChangeHealth
           end
         end
 
-        def self.delete_report(report_name, headers: nil, base_uri: nil, auth_headers: nil)
+        def self.delete_report(report_name, headers: nil, base_uri: nil, endpoint: nil, auth_headers: nil)
           return if report_name.nil? || report_name.empty?
 
           final_headers = ChangeHealth::Request::Claim::Report.report_headers(headers)
 
-          endpoint = ChangeHealth::Connection.endpoint_for(self)
+          endpoint ||= ChangeHealth::Connection.endpoint_for(self)
           individual_report_endpoint = "#{endpoint}/#{report_name}"
 
           ChangeHealth::Connection.new.request(

--- a/lib/change_health/version.rb
+++ b/lib/change_health/version.rb
@@ -1,3 +1,3 @@
 module ChangeHealth
-  VERSION = '5.13.4'.freeze
+  VERSION = '5.14.0'.freeze
 end

--- a/lib/change_health/version.rb
+++ b/lib/change_health/version.rb
@@ -1,3 +1,3 @@
 module ChangeHealth
-  VERSION = '5.13.3'.freeze
+  VERSION = '5.13.4'.freeze
 end

--- a/test/change_health/request/report_test.rb
+++ b/test/change_health/request/report_test.rb
@@ -215,6 +215,39 @@ class ReportTest < Minitest::Test
       end
     end
 
+    describe 'can use custom endpoint per request' do
+      let(:endpoint) { '/different/endpoint' }
+
+      it '#report_list' do
+        stub_change_health(endpoint: endpoint, verb: :get)
+        claim_report.report_list(endpoint: endpoint)
+        assert_requested(@stub)
+      end
+
+      describe '#get_report' do
+        let(:report_name) { 'R5000000.XY' }
+        it 'single report' do
+          stub_change_health(endpoint: endpoint + "/#{report_name}", verb: :get)
+          claim_report.get_report(report_name, as_json_report: false, endpoint: endpoint)
+          assert_requested(@stub)
+        end
+
+        it 'custom report type' do
+          report_type = '999'
+          stub_change_health(endpoint: endpoint + "/#{report_name}/#{report_type}", verb: :get)
+          claim_report.get_report(report_name, report_type: report_type, endpoint: endpoint)
+          assert_requested(@stub)
+        end
+      end
+
+      it '#delete_report' do
+        report_name = 'X3000000.XX'
+        stub_change_health(endpoint: endpoint + "/#{report_name}", verb: :delete)
+        claim_report.delete_report(report_name, endpoint: endpoint)
+        assert_requested(@stub)
+      end
+    end
+
     describe 'can use custom auth headers per request' do
       let(:endpoint) { ChangeHealth::Request::Claim::Report::ENDPOINT }
       let(:new_auth_header) { { Authorization: 'mytoken', other_header: 'hi' } }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -54,11 +54,12 @@ class Minitest::Test
     return response
   end
 
-  def stub_change_health_auth(body: nil, response: nil)
+  def stub_change_health_auth(body: nil, response: nil, base_uri: nil)
+    base_uri ||= ChangeHealth.configuration.api_endpoint
     body ||= { client_id: '123', client_secret: 'abc', grant_type: 'cat' }
     response ||= build_response(body: { access_token: 'let.me.in', expires_in: 3600, token_type: 'bearer' })
 
-    @auth_stub = stub_request(:post, File.join(ChangeHealth.configuration.api_endpoint, ChangeHealth::Authentication::AUTH_ENDPOINT))
+    @auth_stub = stub_request(:post, File.join(base_uri, ChangeHealth::Authentication::AUTH_ENDPOINT))
       .with(body: body)
       .to_return(response)
   end
@@ -68,7 +69,7 @@ class Minitest::Test
     response ||= build_response(body: {})
 
     if true == setup_auth
-      stub_change_health_auth
+      stub_change_health_auth(base_uri: base_uri)
     end
 
     @stub = stub_request(verb, File.join(base_uri, endpoint)).to_return(response)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -63,13 +63,14 @@ class Minitest::Test
       .to_return(response)
   end
 
-  def stub_change_health(endpoint: , setup_auth: true, response: nil, verb: :post)
+  def stub_change_health(endpoint: , setup_auth: true, response: nil, verb: :post, base_uri: nil)
+    base_uri ||= ChangeHealth.configuration.api_endpoint
     response ||= build_response(body: {})
 
     if true == setup_auth
       stub_change_health_auth
     end
 
-    @stub = stub_request(verb, File.join(ChangeHealth.configuration.api_endpoint, endpoint)).to_return(response)
+    @stub = stub_request(verb, File.join(base_uri, endpoint)).to_return(response)
   end
 end


### PR DESCRIPTION
For report request methods, added three additional parameters: `base_uri`, `endpoint` and `auth_headers`. Providing values for these will override the defaults set in the Configuration. All three are optional and will fallback to the Configuration values if not provided.