### PR TITLE
hiranmayee/Allow Alternate URL for Submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+# [5.14.0] - 2024-06-11
+
+### Added
+
+* The following report methods can override the base URI, endpoint, and authentication headers per request if needed:
+  - `ChangeHealth::Request::Claim::Report.report_list`
+  - `ChangeHealth::Request::Claim::Report.get_report`
+  - `ChangeHealth::Request::Claim::Report.delete_report`
+
+  Provide the following parameters to override the defaults set in Configuration:
+  - `base_uri`
+  - `endpoint`
+  - `auth_headers` - an empty hash can also be provided (`{}`), which will issue a request to the authentication endpoint instead of using the configured headers.
+
 # [5.13.3] - 2024-05-20
 
 ### Fixed
@@ -692,6 +706,7 @@ Added the ability to hit professional claim submission API. For more details, se
 * Authentication
 * Configuration
 
+[5.14.0]: https://github.com/WeInfuse/change_health/compare/v5.13.3...v5.14.0
 [5.13.3]: https://github.com/WeInfuse/change_health/compare/v5.13.2...v5.13.3
 [5.13.2]: https://github.com/WeInfuse/change_health/compare/v5.13.1...v5.13.2
 [5.13.1]: https://github.com/WeInfuse/change_health/compare/v5.13.0...v5.13.1

--- a/lib/change_health/authentication.rb
+++ b/lib/change_health/authentication.rb
@@ -9,14 +9,15 @@ module ChangeHealth
       @request_time = nil
     end
 
-    def authenticate
+    def authenticate(base_uri: nil)
       if (self.expires?)
+        base_uri ||= Connection.base_uri
         request = {
           body: { client_id: ChangeHealth.configuration.client_id, client_secret: ChangeHealth.configuration.client_secret, grant_type: ChangeHealth.configuration.grant_type },
           endpoint: AUTH_ENDPOINT
         }
 
-        response = Connection.new.request(**request, auth: false)
+        response = Connection.new.request(**request, auth: false, base_uri: base_uri)
 
         if (false == response.ok?)
           @response = nil

--- a/lib/change_health/request/report.rb
+++ b/lib/change_health/request/report.rb
@@ -5,11 +5,16 @@ module ChangeHealth
         ENDPOINT = '/medicalnetwork/reports/v2'.freeze
         HEALTH_CHECK_ENDPOINT = ENDPOINT + '/healthcheck'.freeze
 
-        def self.report_list(headers: nil, more_url: nil)
-          endpoint = ChangeHealth::Connection.endpoint_for(self) + more_url.to_s
+        def self.report_list(headers: nil, more_url: nil, base_uri: nil, endpoint: nil, auth_headers: nil)
+          endpoint ||= ChangeHealth::Connection.endpoint_for(self)
+          endpoint += more_url.to_s
           final_headers = ChangeHealth::Request::Claim::Report.report_headers(headers)
           ChangeHealth::Response::Claim::ReportListData.new(response: ChangeHealth::Connection.new.request(
-            endpoint: endpoint, verb: :get, headers: final_headers
+            endpoint: endpoint,
+            verb: :get,
+            headers: final_headers,
+            base_uri: base_uri,
+            auth_headers: auth_headers
           ))
         end
 
@@ -17,13 +22,16 @@ module ChangeHealth
           report_name,
           as_json_report: true,
           headers: nil,
-          report_type: nil
+          report_type: nil,
+          base_uri: nil,
+          endpoint: nil,
+          auth_headers: nil
         )
           return if report_name.nil? || report_name.empty?
 
           final_headers = ChangeHealth::Request::Claim::Report.report_headers(headers)
 
-          endpoint = ChangeHealth::Connection.endpoint_for(self)
+          endpoint ||= ChangeHealth::Connection.endpoint_for(self)
 
           individual_report_endpoint = "#{endpoint}/#{report_name}"
 
@@ -38,7 +46,9 @@ module ChangeHealth
           response = ChangeHealth::Connection.new.request(
             endpoint: individual_report_endpoint,
             verb: :get,
-            headers: final_headers
+            headers: final_headers,
+            base_uri: base_uri,
+            auth_headers: auth_headers
           )
           if ChangeHealth::Response::Claim::ReportData.is_277?(report_name)
             ChangeHealth::Response::Claim::Report277Data
@@ -58,18 +68,20 @@ module ChangeHealth
           end
         end
 
-        def self.delete_report(report_name, headers: nil)
+        def self.delete_report(report_name, headers: nil, base_uri: nil, endpoint: nil, auth_headers: nil)
           return if report_name.nil? || report_name.empty?
 
           final_headers = ChangeHealth::Request::Claim::Report.report_headers(headers)
 
-          endpoint = ChangeHealth::Connection.endpoint_for(self)
+          endpoint ||= ChangeHealth::Connection.endpoint_for(self)
           individual_report_endpoint = "#{endpoint}/#{report_name}"
 
           ChangeHealth::Connection.new.request(
             endpoint: individual_report_endpoint,
             verb: :delete,
-            headers: final_headers
+            headers: final_headers,
+            base_uri: base_uri,
+            auth_headers: auth_headers
           )
         end
 

--- a/lib/change_health/request/submission.rb
+++ b/lib/change_health/request/submission.rb
@@ -40,14 +40,15 @@ module ChangeHealth
           self[:providers] << provider
         end
 
-        def submission(is_professional: true, headers: nil)
+        def submission(is_professional: true, headers: nil, endpoint: nil)
+          endpoint ||= self.class.endpoint(
+            is_professional: is_professional,
+            suffix: SUBMISSION_SUFFIX
+          )
           headers ||= is_professional ? professional_headers : institutional_headers
           ChangeHealth::Response::Claim::SubmissionData.new(
             response: ChangeHealth::Connection.new.request(
-              endpoint: self.class.endpoint(
-                is_professional: is_professional,
-                suffix: SUBMISSION_SUFFIX
-              ),
+              endpoint: endpoint,
               body: to_h,
               headers: headers
             )

--- a/lib/change_health/version.rb
+++ b/lib/change_health/version.rb
@@ -1,3 +1,3 @@
 module ChangeHealth
-  VERSION = '5.13.3'.freeze
+  VERSION = '5.14.0'.freeze
 end

--- a/test/change_health/request/report_test.rb
+++ b/test/change_health/request/report_test.rb
@@ -180,5 +180,122 @@ class ReportTest < Minitest::Test
         assert_requested(@stub)
       end
     end
+
+    describe 'can use custom base uri per request' do
+      let(:endpoint) { ChangeHealth::Request::Claim::Report::ENDPOINT }
+      let(:new_base_uri) { 'different.uri' }
+
+      it '#report_list' do
+        stub_change_health(endpoint: endpoint, verb: :get, base_uri: new_base_uri)
+        claim_report.report_list(base_uri: new_base_uri)
+        assert_requested(@stub)
+      end
+
+      describe '#get_report' do
+        let(:report_name) { 'R5000000.XY' }
+        it 'single report' do
+          stub_change_health(endpoint: endpoint + "/#{report_name}", verb: :get, base_uri: new_base_uri)
+          claim_report.get_report(report_name, as_json_report: false, base_uri: new_base_uri)
+          assert_requested(@stub)
+        end
+
+        it 'custom report type' do
+          report_type = '999'
+          stub_change_health(endpoint: endpoint + "/#{report_name}/#{report_type}", verb: :get, base_uri: new_base_uri)
+          claim_report.get_report(report_name, report_type: report_type, base_uri: new_base_uri)
+          assert_requested(@stub)
+        end
+      end
+
+      it '#delete_report' do
+        report_name = 'X3000000.XX'
+        stub_change_health(endpoint: endpoint + "/#{report_name}", verb: :delete, base_uri: new_base_uri)
+        claim_report.delete_report(report_name, base_uri: new_base_uri)
+        assert_requested(@stub)
+      end
+    end
+
+    describe 'can use custom endpoint per request' do
+      let(:endpoint) { '/different/endpoint' }
+
+      it '#report_list' do
+        stub_change_health(endpoint: endpoint, verb: :get)
+        claim_report.report_list(endpoint: endpoint)
+        assert_requested(@stub)
+      end
+
+      describe '#get_report' do
+        let(:report_name) { 'R5000000.XY' }
+        it 'single report' do
+          stub_change_health(endpoint: endpoint + "/#{report_name}", verb: :get)
+          claim_report.get_report(report_name, as_json_report: false, endpoint: endpoint)
+          assert_requested(@stub)
+        end
+
+        it 'custom report type' do
+          report_type = '999'
+          stub_change_health(endpoint: endpoint + "/#{report_name}/#{report_type}", verb: :get)
+          claim_report.get_report(report_name, report_type: report_type, endpoint: endpoint)
+          assert_requested(@stub)
+        end
+      end
+
+      it '#delete_report' do
+        report_name = 'X3000000.XX'
+        stub_change_health(endpoint: endpoint + "/#{report_name}", verb: :delete)
+        claim_report.delete_report(report_name, endpoint: endpoint)
+        assert_requested(@stub)
+      end
+    end
+
+    describe 'can use custom auth headers per request' do
+      let(:endpoint) { ChangeHealth::Request::Claim::Report::ENDPOINT }
+      let(:new_auth_header) { { Authorization: 'mytoken', other_header: 'hi' } }
+      let(:report_name) { 'R5000000.XY' }
+
+      before do
+        @config = ChangeHealth.configuration.to_h
+
+        # set default headers so we can assert they are overridden
+        default_headers = { Authorization: 'different.token', other_header: 'hello' }
+        ChangeHealth.configuration.auth_headers = default_headers
+
+        WebMock.after_request do |request, _response|
+          @request = request
+        end
+      end
+
+      after do
+        ChangeHealth.configuration.from_h(@config)
+      end
+
+      it '#report_list' do
+        stub_change_health(endpoint: endpoint, verb: :get)
+        claim_report.report_list(auth_headers: new_auth_header)
+
+        assert_not_requested(@auth_stub)
+        assert_requested(@stub)
+        assert_equal('mytoken', @request.headers['Authorization'])
+        assert_equal('hi', @request.headers['Other-Header'])
+      end
+
+      it '#get_report' do
+        stub_change_health(endpoint: endpoint + "/#{report_name}", verb: :get)
+        claim_report.get_report(report_name, as_json_report: false, auth_headers: {})
+
+        assert_requested(@auth_stub)
+        assert_requested(@stub)
+      end
+
+      it '#delete_report' do
+        stub_change_health(endpoint: endpoint + "/#{report_name}", verb: :delete)
+        claim_report.delete_report(report_name, auth_headers: new_auth_header)
+
+        assert_not_requested(@auth_stub)
+        assert_requested(@stub)
+        assert_equal('mytoken', @request.headers['Authorization'])
+        assert_equal('hi', @request.headers['Other-Header'])
+      end
+    end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -54,22 +54,24 @@ class Minitest::Test
     return response
   end
 
-  def stub_change_health_auth(body: nil, response: nil)
+  def stub_change_health_auth(body: nil, response: nil, base_uri: nil)
+    base_uri ||= ChangeHealth.configuration.api_endpoint
     body ||= { client_id: '123', client_secret: 'abc', grant_type: 'cat' }
     response ||= build_response(body: { access_token: 'let.me.in', expires_in: 3600, token_type: 'bearer' })
 
-    @auth_stub = stub_request(:post, File.join(ChangeHealth.configuration.api_endpoint, ChangeHealth::Authentication::AUTH_ENDPOINT))
+    @auth_stub = stub_request(:post, File.join(base_uri, ChangeHealth::Authentication::AUTH_ENDPOINT))
       .with(body: body)
       .to_return(response)
   end
 
-  def stub_change_health(endpoint: , setup_auth: true, response: nil, verb: :post)
+  def stub_change_health(endpoint: , setup_auth: true, response: nil, verb: :post, base_uri: nil)
+    base_uri ||= ChangeHealth.configuration.api_endpoint
     response ||= build_response(body: {})
 
     if true == setup_auth
-      stub_change_health_auth
+      stub_change_health_auth(base_uri: base_uri)
     end
 
-    @stub = stub_request(verb, File.join(ChangeHealth.configuration.api_endpoint, endpoint)).to_return(response)
+    @stub = stub_request(verb, File.join(base_uri, endpoint)).to_return(response)
   end
 end


### PR DESCRIPTION
Allow optional alternate endpoint for submission. Defaults to the original endpoint if no alternative is provided.