### PR TITLE
hiranmayee/Allow Alternate URI for Submission

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,12 @@
 version: 2.1 
 
 orbs:
-  ruby: circleci/ruby@0.1.2 # Ruby orb registry: https://circleci.com/orbs/registry/orb/circleci/ruby
+  ruby: circleci/ruby@0.2.1.3 # Ruby orb registry: https://circleci.com/orbs/registry/orb/circleci/ruby
 
 jobs: 
   build: 
     docker: 
-      - image: circleci/ruby:2.4
+      - image: circleci/ruby:2.7
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1 
 
 orbs:
-  ruby: circleci/ruby@0.2.1.3 # Ruby orb registry: https://circleci.com/orbs/registry/orb/circleci/ruby
+  ruby: circleci/ruby@2.1.3 # Ruby orb registry: https://circleci.com/orbs/registry/orb/circleci/ruby
 
 jobs: 
   build: 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -712,7 +712,7 @@ Added the ability to hit professional claim submission API. For more details, se
 * Authentication
 * Configuration
 
-[5.15.0]: https://github.com/WeInfuse/change_health/compare/v5.14.3...v5.15.0
+[5.15.0]: https://github.com/WeInfuse/change_health/compare/v5.14.0...v5.15.0
 [5.14.0]: https://github.com/WeInfuse/change_health/compare/v5.13.3...v5.14.0
 [5.13.3]: https://github.com/WeInfuse/change_health/compare/v5.13.2...v5.13.3
 [5.13.2]: https://github.com/WeInfuse/change_health/compare/v5.13.1...v5.13.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+# [5.15.0] - 2024-06-19
+
+### Added
+
+* Ability to accept alternate `base_uri` and `auth_headers` in submission.
+
 # [5.14.0] - 2024-06-11
 
 ### Added
@@ -706,6 +712,7 @@ Added the ability to hit professional claim submission API. For more details, se
 * Authentication
 * Configuration
 
+[5.15.0]: https://github.com/WeInfuse/change_health/compare/v5.14.3...v5.15.0
 [5.14.0]: https://github.com/WeInfuse/change_health/compare/v5.13.3...v5.14.0
 [5.13.3]: https://github.com/WeInfuse/change_health/compare/v5.13.2...v5.13.3
 [5.13.2]: https://github.com/WeInfuse/change_health/compare/v5.13.1...v5.13.2

--- a/lib/change_health/request/submission.rb
+++ b/lib/change_health/request/submission.rb
@@ -40,7 +40,7 @@ module ChangeHealth
           self[:providers] << provider
         end
 
-        def submission(is_professional: true, headers: nil, base_uri:, auth_headers:)
+        def submission(is_professional: true, headers: nil, base_uri: nil, auth_headers: nil)
           headers ||= is_professional ? professional_headers : institutional_headers
           ChangeHealth::Response::Claim::SubmissionData.new(
             response: ChangeHealth::Connection.new.request(

--- a/lib/change_health/request/submission.rb
+++ b/lib/change_health/request/submission.rb
@@ -40,7 +40,7 @@ module ChangeHealth
           self[:providers] << provider
         end
 
-        def submission(is_professional: true, headers: nil)
+        def submission(is_professional: true, headers: nil, base_uri:, auth_headers:)
           headers ||= is_professional ? professional_headers : institutional_headers
           ChangeHealth::Response::Claim::SubmissionData.new(
             response: ChangeHealth::Connection.new.request(
@@ -48,8 +48,10 @@ module ChangeHealth
                 is_professional: is_professional,
                 suffix: SUBMISSION_SUFFIX
               ),
+              base_uri: base_uri,
               body: to_h,
-              headers: headers
+              headers: headers,
+              auth_headers: auth_headers
             )
           )
         end

--- a/lib/change_health/version.rb
+++ b/lib/change_health/version.rb
@@ -1,3 +1,3 @@
 module ChangeHealth
-  VERSION = '5.14.0'.freeze
+  VERSION = '5.15.0'.freeze
 end


### PR DESCRIPTION
Allow optional alternate uri and auth headers for submission. Defaults to the original setup if no alternative is provided.